### PR TITLE
Set elements to [] instead of null in the case of an empty transcript, close #52

### DIFF
--- a/src/Components/PaperEditor/ProgrammeScriptContainer/index.js
+++ b/src/Components/PaperEditor/ProgrammeScriptContainer/index.js
@@ -86,7 +86,9 @@ const ProgrammeScript = props => {
       try {
         const paperEdit = await PaperEditsCollection.getItem(papereditsId);
         setTitle(paperEdit.title);
-        const newElements = JSON.parse(JSON.stringify(paperEdit.elements));
+        const newElements = paperEdit.elements ?
+          JSON.parse(JSON.stringify(paperEdit.elements)) :
+          [];
         const insertElement = {
           type: 'insert',
           text: 'Insert point to add selection'


### PR DESCRIPTION
**Is your Pull Request request related to another [issue](https://github.com/bbc/react-transcript-editor/issues) in this repository ?**      

- Closes #52 

**Describe what the PR does**    

Ensures that an element can be added to an empty transcript by using a ternary to set elements to an empty array instead of null in the case that `paperEdit.elements` is empty.

**State whether the PR is ready for review or whether it needs extra work**    

- Ready for review