### PR TITLE
Floor the progress percentage so it always shows an integer

### DIFF
--- a/src/Components/Workspace/Transcripts/index.js
+++ b/src/Components/Workspace/Transcripts/index.js
@@ -99,7 +99,7 @@ const Transcripts = props => {
   };
 
   const handleUploadProgress = (id, snapshot) => {
-    var progress = (snapshot.bytesTransferred / snapshot.totalBytes) * 100;
+    const progress = Math.floor((snapshot.bytesTransferred / snapshot.totalBytes) * 100);
     updateUploadTasksProgress(id, progress);
   };
 


### PR DESCRIPTION
Tiny PR, related to https://github.com/bbc/digital-paper-edit-storybook/issues/35 but this change is in firebase not storybook.

Avoiding "undefined" doesn't seem possible at this end - I'll try and fix that separately in storybook.