### PR TITLE
i73-adds-default-label

### DIFF
--- a/src/Components/Projects/index.js
+++ b/src/Components/Projects/index.js
@@ -16,20 +16,10 @@ const Projects = props => {
   const type = 'Project';
   const collection = new Collection(props.firebase, PROJECTS);
 
-  const createProject = async item => {
-    item.users = [ uid ];
-    const docRef = await collection.postItem(item);
-
-    item.url = `/projects/${ docRef.id }`;
-    docRef.update({
-      url: item.url
-    });
-
-    item.display = true;
-
+  const createDefaultLabel = async (projectId) => {
     const LabelsCollection = new Collection(
       props.firebase,
-      `/projects/${ docRef.id }/labels`
+      `/projects/${ projectId }/labels`
     );
 
     const defaultLabel = {
@@ -44,6 +34,20 @@ const Projects = props => {
     labelDocRef.update({
       id: labelDocRef.id
     });
+  };
+
+  const createProject = async item => {
+    item.users = [ uid ];
+    const docRef = await collection.postItem(item);
+
+    item.url = `/projects/${ docRef.id }`;
+    docRef.update({
+      url: item.url
+    });
+
+    item.display = true;
+
+    createDefaultLabel(docRef.id);
 
     return item;
   };

--- a/src/Components/Projects/index.js
+++ b/src/Components/Projects/index.js
@@ -27,6 +27,24 @@ const Projects = props => {
 
     item.display = true;
 
+    const LabelsCollection = new Collection(
+      props.firebase,
+      `/projects/${ docRef.id }/labels`
+    );
+
+    const defaultLabel = {
+      label: 'Default',
+      color: 'yellow',
+      value: 'yellow',
+      description: ''
+    };
+
+    const labelDocRef = await LabelsCollection.postItem(defaultLabel);
+
+    labelDocRef.update({
+      id: labelDocRef.id
+    });
+
     return item;
   };
 

--- a/src/Components/Workspace/PaperEdits/index.js
+++ b/src/Components/Workspace/PaperEdits/index.js
@@ -12,11 +12,6 @@ const PaperEdits = props => {
     `/projects/${ props.projectId }/paperedits`
   );
 
-  const LabelsCollection = new Collection(
-    props.firebase,
-    `/projects/${ props.projectId }/labels`
-  );
-
   const [ items, setItems ] = useState([]);
   const [ loading, setIsLoading ] = useState(false);
 
@@ -56,19 +51,6 @@ const PaperEdits = props => {
     });
 
     item.display = true;
-
-    const defaultLabel = {
-      label: 'Default',
-      color: 'yellow',
-      value: 'yellow',
-      description: ''
-    };
-
-    const labelDocRef = await LabelsCollection.postItem(defaultLabel);
-
-    labelDocRef.update({
-      id: labelDocRef.id
-    });
 
     return item;
   };

--- a/src/Components/Workspace/PaperEdits/index.js
+++ b/src/Components/Workspace/PaperEdits/index.js
@@ -11,6 +11,12 @@ const PaperEdits = props => {
     props.firebase,
     `/projects/${ props.projectId }/paperedits`
   );
+
+  const LabelsCollection = new Collection(
+    props.firebase,
+    `/projects/${ props.projectId }/labels`
+  );
+
   const [ items, setItems ] = useState([]);
   const [ loading, setIsLoading ] = useState(false);
 
@@ -50,6 +56,19 @@ const PaperEdits = props => {
     });
 
     item.display = true;
+
+    const defaultLabel = {
+      label: 'Default',
+      color: 'yellow',
+      value: 'yellow',
+      description: ''
+    };
+
+    const labelDocRef = await LabelsCollection.postItem(defaultLabel);
+
+    labelDocRef.update({
+      id: labelDocRef.id
+    });
 
     return item;
   };


### PR DESCRIPTION
**Is your Pull Request request related to another [issue](https://github.com/bbc/react-transcript-editor/issues) in this repository ?**      
<!-- _If so please link to other issues and PRs as appropriate_ -->
#73 

**Describe what the PR does**    
<!-- _A clear and concise description of what the PR does. Feel free to use bulletpoints and checkboxes if needed [...]_ -->
- [ ] Creates a default label when a new paper edit project is created (in `Workspace/PaperEdits/index.js`

There is already functionality in the TranscriptContainer for making a label with a label value of 'Default' un-editable. 

**State whether the PR is ready for review or whether it needs extra work**    
<!-- _If you are still working on it and just setting it up for later review, or if it's ready to be reviewed for merging_ -->
Ready

**Additional context**    
<!-- Add any other context or screenshots about the PR. -->
To test:

- [ ] Create new project
- [ ] Create a new paper edit
- [ ] Check that in the TranscriptTabContainer, a Default label appears in the label list
  - [ ] This cannot be edited
  - [ ] This cannot be deleted

<!-- 
## User Story / Context
|As a ...|I want ...|So that ...|
|-|-|-|
|<Who>|<What>|<Why>|

## Acceptance Criteria
- <Criteria to satisfy the PR Issue>

## Definitions of Done
- [ ] Runs locally
- [ ] Runs remotely
- [ ] Test passes
- [ ] Demonstrated
- [ ] Deployed to Cosmos on Test and Live
- [ ] Documentation
  - [ ] Developer Documentation - [repo's README|<link>]
  - [ ] Stakeholder Documentation - [Confluence|<link>]
  - [ ] Operational Documentation - [Runbook|<link>]
- [ ] Peer reviewed by:
-->
