### PR TITLE
Alert when trying to export empty ADL because it breaks, close #42

### DIFF
--- a/src/Components/PaperEditor/ProgrammeScriptContainer/ExportDropdown/index.js
+++ b/src/Components/PaperEditor/ProgrammeScriptContainer/ExportDropdown/index.js
@@ -102,10 +102,13 @@ const ExportDropdown = (props) => {
   };
 
   const handleExportADL = () => {
-    // alert('this function has not been implemented yet');
     const edlSq = getSequenceJsonEDL();
+    if (edlSq.events.length == 0) {
+      alert('Cannot export empty paper edit ADL');
+
+      return;
+    }
     const firstElement = edlSq.events[0];
-    // const result = generateADL(edlSq);
     const result = generateADL({
       projectOriginator: 'Digital Paper Edit',
       // TODO: it be good to change sequence for the ADL to be same schema
@@ -123,7 +126,6 @@ const ExportDropdown = (props) => {
       frameRate: firstElement.fps,
       projectName: edlSq.title
     });
-
     console.log('ADL Result', result);
     downloadjs(result, `${ title }.adl`, 'text/plain');
   };


### PR DESCRIPTION
**Is your Pull Request request related to another [issue](https://github.com/bbc/react-transcript-editor/issues) in this repository ?**      

- Closes #42 

**Describe what the PR does**    

- Shows an alert message when the user tries to export the ADL of an empty paper edit, instead of crashing

**State whether the PR is ready for review or whether it needs extra work**    

- Ready for review

**Additional context**    

Not entirely sure this is the right call. All the other export options work successfully for an empty paper edit, but this PR makes ADL different.

Alternatives:

- Fix `generateADL` in [bbc/aes31-adl-composer](https://github.com/bbc/aes31-adl-composer/blob/master/src/index.js#L87) to deal with the edge case of no edits
- Make the other exports show an alert when the paper edit is empty
- Hide/disable export button when paper edit is empty

Please review, decide if this is the right way to get around the issue, or suggest an alternative.