### PR TITLE
Fix manual colour selection in label form

### DIFF
--- a/src/Components/PaperEditor/TranscriptsContainer/LabelsList/LabelForm.js
+++ b/src/Components/PaperEditor/TranscriptsContainer/LabelsList/LabelForm.js
@@ -48,8 +48,9 @@ const LabelForm = (props) => {
     setColor(randomColor());
   };
 
-  const handleColorPickerChangeComplete = () => {
-    setColor({ color: chroma(color.hex).name() });
+  const handleColorPickerChangeComplete = (e) => {
+    const colorValue = e.hex;
+    setColor(chroma.valid(colorValue) ? chroma(colorValue).name() : colorValue);
   };
 
   const handleManualColorChange = (e) => {

--- a/src/Components/PaperEditor/TranscriptsContainer/LabelsList/LabelForm.js
+++ b/src/Components/PaperEditor/TranscriptsContainer/LabelsList/LabelForm.js
@@ -50,7 +50,7 @@ const LabelForm = (props) => {
 
   const handleColorPickerChangeComplete = (e) => {
     const colorValue = e.hex;
-    setColor(chroma.valid(colorValue) ? chroma(colorValue).name() : colorValue);
+    setColor(chroma(colorValue).name());
   };
 
   const handleManualColorChange = (e) => {


### PR DESCRIPTION
**Is your Pull Request request related to another [issue](https://github.com/bbc/react-transcript-editor/issues) in this repository ?**      
<!-- _If so please link to other issues and PRs as appropriate_ -->
#95 

**Describe what the PR does**    
<!-- _A clear and concise description of what the PR does. Feel free to use bulletpoints and checkboxes if needed [...]_ -->
Fixes the manual colour picker so that it doesn't crash the paper-edit view. 

The code was originally setting the `color` value in state to be an object with a `color` field. This just saves the value. The error handling is still not brilliant but because the hex codes are just pulled from a list we've hard-coded I think this is fine for now. 

**State whether the PR is ready for review or whether it needs extra work**    
<!-- _If you are still working on it and just setting it up for later review, or if it's ready to be reviewed for merging_ -->
Ready

**Additional context**    
<!-- Add any other context or screenshots about the PR. -->
To test:

- [ ] Go to paper-edit view and select 'Create new label':
  - [ ] Ensure that the label creates and annotates when you manually pick a colour
  - [ ] Ensure the randomise colour functionality still works too

<!-- 
## User Story / Context
|As a ...|I want ...|So that ...|
|-|-|-|
|<Who>|<What>|<Why>|

## Acceptance Criteria
- <Criteria to satisfy the PR Issue>

## Definitions of Done
- [ ] Runs locally
- [ ] Runs remotely
- [ ] Test passes
- [ ] Demonstrated
- [ ] Deployed to Cosmos on Test and Live
- [ ] Documentation
  - [ ] Developer Documentation - [repo's README|<link>]
  - [ ] Stakeholder Documentation - [Confluence|<link>]
  - [ ] Operational Documentation - [Runbook|<link>]
- [ ] Peer reviewed by:
-->
