### PR TITLE
Automatically saving programme script on change

### DIFF
--- a/src/Components/PaperEditor/ProgrammeScriptContainer/index.js
+++ b/src/Components/PaperEditor/ProgrammeScriptContainer/index.js
@@ -178,6 +178,7 @@ const ProgrammeScriptContainer = (props) => {
       setElements(newElements);
       setResetPreview(true);
       console.log('Deleted');
+      handleSaveProgrammeScript();
     } else {
       console.log('Not deleting');
     }
@@ -205,12 +206,14 @@ const ProgrammeScriptContainer = (props) => {
     const newElements = arrayMove(elements, oldIndex, newIndex);
     setElements(newElements);
     setResetPreview(true);
+    handleSaveProgrammeScript();
   };
 
   const getInsertElementIndex = () => {
     const insertElement = elements.find((el) => {
       return el.type === 'insert';
     });
+    handleSaveProgrammeScript();
 
     return elements.indexOf(insertElement);
   };

--- a/src/Components/PaperEditor/ProgrammeScriptContainer/index.js
+++ b/src/Components/PaperEditor/ProgrammeScriptContainer/index.js
@@ -356,18 +356,6 @@ const ProgrammeScriptContainer = (props) => {
                 elements={ elements }
               ></ExportDropdown>
             </Col>
-            <Col sm={ 12 } md={ 1 }>
-              <Button
-                variant="outline-secondary"
-                onClick={ hadleSaveButton }
-                // size="sm"
-                title="save programme script"
-                block
-              >
-                <FontAwesomeIcon icon={ faSave } />
-                {/* Save */}
-              </Button>
-            </Col>
           </Row>
         </Card.Header>
         <Card.Body>

--- a/src/Components/PaperEditor/ProgrammeScriptContainer/index.js
+++ b/src/Components/PaperEditor/ProgrammeScriptContainer/index.js
@@ -8,7 +8,7 @@ import arrayMove from 'array-move';
 import { SortableContainer } from 'react-sortable-hoc';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faPlus, faSave } from '@fortawesome/free-solid-svg-icons';
+import { faPlus } from '@fortawesome/free-solid-svg-icons';
 
 import PreviewCanvas from '@bbc/digital-paper-edit-storybook/PreviewCanvas';
 import ProgrammeElements from '@bbc/digital-paper-edit-storybook/ProgrammeElements';
@@ -196,6 +196,7 @@ const ProgrammeScriptContainer = (props) => {
       setElements(newElements);
       setResetPreview(true);
       console.log('Edited');
+      handleSaveProgrammeScript();
     } else {
       // either newText is empty or they hit cancel
       console.log('Not editing');
@@ -309,6 +310,7 @@ const ProgrammeScriptContainer = (props) => {
         newElements.splice(insertElementIndex, 0, newElement);
         setElements(newElements);
         console.log('Added element');
+        handleSaveProgrammeScript();
         setResetPreview(true);
       } else {
         console.log('Not adding element');
@@ -351,21 +353,6 @@ const ProgrammeScriptContainer = (props) => {
                 elements={ elements }
               ></ExportDropdown>
             </Col>
-<<<<<<< HEAD
-=======
-            <Col sm={ 12 } md={ 1 }>
-              <Button
-                variant="outline-secondary"
-                onClick={ handleSaveButton }
-                // size="sm"
-                title="save programme script"
-                block
-              >
-                <FontAwesomeIcon icon={ faSave } />
-                {/* Save */}
-              </Button>
-            </Col>
->>>>>>> 7dafbcbb0bac11f870a7dc7eb800f5705415a164
           </Row>
         </Card.Header>
         <Card.Body>

--- a/src/Components/PaperEditor/ProgrammeScriptContainer/index.js
+++ b/src/Components/PaperEditor/ProgrammeScriptContainer/index.js
@@ -50,10 +50,10 @@ const ProgrammeScriptContainer = (props) => {
     `/projects/${ projectId }/paperedits`
   );
 
-  const handleSaveProgrammeScript = async () => {
+  const handleSaveProgrammeScript = async (newelements) => {
     console.log('Saving...');
-    if (elements) {
-      const newElements = JSON.parse(JSON.stringify(elements));
+    if (newelements) {
+      const newElements = JSON.parse(JSON.stringify(newelements));
       const insertPointElement = newElements.find((el) => el.type === 'insert');
 
       if (insertPointElement) {
@@ -178,7 +178,7 @@ const ProgrammeScriptContainer = (props) => {
       setElements(newElements);
       setResetPreview(true);
       console.log('Deleted');
-      handleSaveProgrammeScript();
+      handleSaveProgrammeScript(newElements);
     } else {
       console.log('Not deleting');
     }
@@ -196,7 +196,7 @@ const ProgrammeScriptContainer = (props) => {
       setElements(newElements);
       setResetPreview(true);
       console.log('Edited');
-      handleSaveProgrammeScript();
+      handleSaveProgrammeScript(newElements);
     } else {
       // either newText is empty or they hit cancel
       console.log('Not editing');
@@ -207,7 +207,7 @@ const ProgrammeScriptContainer = (props) => {
     const newElements = arrayMove(elements, oldIndex, newIndex);
     setElements(newElements);
     setResetPreview(true);
-    handleSaveProgrammeScript();
+    handleSaveProgrammeScript(newElements);
   };
 
   const getInsertElementIndex = () => {
@@ -264,7 +264,7 @@ const ProgrammeScriptContainer = (props) => {
       }
       newElements.splice(insertElementIndex, 0, newElement);
       setElements(newElements);
-      handleSaveProgrammeScript();
+      handleSaveProgrammeScript(newElements);
       setResetPreview(true);
     } else {
       console.log('nothing selected');
@@ -310,7 +310,7 @@ const ProgrammeScriptContainer = (props) => {
         newElements.splice(insertElementIndex, 0, newElement);
         setElements(newElements);
         console.log('Added element');
-        handleSaveProgrammeScript();
+        handleSaveProgrammeScript(newElements);
         setResetPreview(true);
       } else {
         console.log('Not adding element');

--- a/src/Components/PaperEditor/ProgrammeScriptContainer/index.js
+++ b/src/Components/PaperEditor/ProgrammeScriptContainer/index.js
@@ -75,6 +75,11 @@ const ProgrammeScriptContainer = (props) => {
     }
   };
 
+  const hadleSaveButton = () => {
+    handleSaveProgrammeScript();
+    alert('Programme script has been saved successfully!');
+  };
+
   useEffect(() => {
     const getPaperEdit = async () => {
       try {
@@ -354,7 +359,7 @@ const ProgrammeScriptContainer = (props) => {
             <Col sm={ 12 } md={ 1 }>
               <Button
                 variant="outline-secondary"
-                onClick={ handleSaveProgrammeScript }
+                onClick={ hadleSaveButton }
                 // size="sm"
                 title="save programme script"
                 block

--- a/src/Components/PaperEditor/ProgrammeScriptContainer/index.js
+++ b/src/Components/PaperEditor/ProgrammeScriptContainer/index.js
@@ -218,7 +218,6 @@ const ProgrammeScriptContainer = (props) => {
     const insertElement = elements.find((el) => {
       return el.type === 'insert';
     });
-    handleSaveProgrammeScript();
 
     return elements.indexOf(insertElement);
   };
@@ -269,6 +268,7 @@ const ProgrammeScriptContainer = (props) => {
       }
       newElements.splice(insertElementIndex, 0, newElement);
       setElements(newElements);
+      handleSaveProgrammeScript();
       setResetPreview(true);
     } else {
       console.log('nothing selected');

--- a/src/Components/PaperEditor/ProgrammeScriptContainer/index.js
+++ b/src/Components/PaperEditor/ProgrammeScriptContainer/index.js
@@ -75,11 +75,6 @@ const ProgrammeScriptContainer = (props) => {
     }
   };
 
-  const handleSaveButton = () => {
-    handleSaveProgrammeScript();
-    alert('Programme script has been saved successfully!');
-  };
-
   useEffect(() => {
     const getPaperEdit = async () => {
       try {


### PR DESCRIPTION
Is your Pull Request request related to another issue #93   in this repository ?

Describe what the PR does

The programme script is saved to Firebase after:

  - [x] Insertions
  - [x] Deletions
  - [x] Re-arrangements
AND:
  - [x] The 'Save' button has been modified to reflect whenever a change has been saved, and to trigger a confirmation window. (alert)
  - [ ] We have validated that adding this functionality doesn't appear to slow down the programme in a significant way, or introduce other performance issues

Ready

**Additional context**    
<!-- Add any other context or screenshots about the PR. -->


<!-- 
## User Story / Context
|As a ...|I want ...|So that ...|
|-|-|-|
|<Who>|<What>|<Why>|

## Acceptance Criteria
- <Criteria to satisfy the PR Issue>

## Definitions of Done
- [ ] Runs locally
- [ ] Runs remotely
- [ ] Test passes
- [ ] Demonstrated
- [ ] Deployed to Cosmos on Test and Live
- [ ] Documentation
  - [ ] Developer Documentation - [repo's README|<link>]
  - [ ] Stakeholder Documentation - [Confluence|<link>]
  - [ ] Operational Documentation - [Runbook|<link>]
- [ ] Peer reviewed by:
-->



**State whether the PR is ready for review or whether it needs extra work**    
<!-- _If you are still working on it and just setting it up for later review, or if it's ready to be reviewed for merging_ -->

**Additional context**    
<!-- Add any other context or screenshots about the PR. -->


<!-- 
## User Story / Context
|As a ...|I want ...|So that ...|
|-|-|-|
|<Who>|<What>|<Why>|

## Acceptance Criteria
- <Criteria to satisfy the PR Issue>

## Definitions of Done
- [ ] Runs locally
- [ ] Runs remotely
- [ ] Test passes
- [ ] Demonstrated
- [ ] Deployed to Cosmos on Test and Live
- [ ] Documentation
  - [ ] Developer Documentation - [repo's README|<link>]
  - [ ] Stakeholder Documentation - [Confluence|<link>]
  - [ ] Operational Documentation - [Runbook|<link>]
- [ ] Peer reviewed by:
-->
