### PR TITLE
Saved notification does not reappear and does not show the error version of Alert on firestore operations.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,19 +1,20 @@
+import PropTypes from 'prop-types';
 import React, { useState, useEffect } from 'react';
 import 'bootstrap-css-only/css/bootstrap.css';
-import CustomAlert from '@bbc/digital-paper-edit-storybook/CustomAlert';
 import Container from 'react-bootstrap/Container';
 import Routes from './Routes';
 import SignOutButton from './Components/SignOut';
 import { withAuthentication } from './Components/Session';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
+import Alert from 'react-bootstrap/Alert';
 
-const App = props => {
+const App = (props) => {
   let offlineWarning = null;
   const [ authUser, setAuthUser ] = useState();
 
   useEffect(() => {
-    const authListener = props.firebase.auth.onAuthStateChanged(user =>
+    const authListener = props.firebase.auth.onAuthStateChanged((user) =>
       setAuthUser(user)
     );
 
@@ -27,11 +28,10 @@ const App = props => {
       <>
         <br />
         <Container>
-          <CustomAlert
-            variant={ 'warning' }
-            heading={ 'Offline warning' }
-            message={ "You don't seem to be connected to the internet " }
-          />
+          <Alert variant={ 'warning' }>
+            <Alert.heading>Offline warning</Alert.heading>
+            You don`&apos;`t seem to be connected to the internet
+          </Alert>
         </Container>
       </>
     );
@@ -64,18 +64,24 @@ const App = props => {
       <>
         <Container style={ { marginBottom: '2em', marginTop: '1em' } }>
           <h1> Digital Paper Edit </h1>
-          <p>Please <a href="/">sign in</a> - please request a user and password</p>
+          <p>
+            Please <a href="/">sign in</a> - please request a user and password
+          </p>
         </Container>
         <Routes />
       </>
     );
   }
 
-  return (
-    <>
-      {AppContainer}
-    </>
-  );
+  return <>{AppContainer}</>;
+};
+
+App.propTypes = {
+  firebase: PropTypes.shape({
+    auth: PropTypes.shape({
+      onAuthStateChanged: PropTypes.func,
+    }),
+  }),
 };
 
 export default withAuthentication(App);

--- a/src/Components/Firebase/Collection.js
+++ b/src/Components/Firebase/Collection.js
@@ -38,6 +38,7 @@ class Collection {
       return docRef;
     } catch (error) {
       console.error('Error adding document: ', error);
+      throw (error);
     }
   };
 
@@ -49,6 +50,7 @@ class Collection {
       console.log('Document written with ID: ', id);
     } catch (error) {
       console.error('Error adding document: ', error);
+      throw (error);
     }
   };
 
@@ -61,6 +63,7 @@ class Collection {
     } catch (error) {
       console.error('Error adding document: ', error);
       alert('Error saving document');
+      throw (error);
     }
   };
 

--- a/src/Components/Workspace/Transcripts/TranscriptEditor.js
+++ b/src/Components/Workspace/Transcripts/TranscriptEditor.js
@@ -8,8 +8,8 @@ import Col from 'react-bootstrap/Col';
 import Button from 'react-bootstrap/Button';
 
 import Collection from '../../Firebase/Collection';
+import Alert from 'react-bootstrap/Alert';
 
-import CustomAlert from '@bbc/digital-paper-edit-storybook/CustomAlert';
 import Breadcrumb from '@bbc/digital-paper-edit-storybook/Breadcrumb';
 
 const TranscriptEditor = ({ match, firebase }) => {
@@ -20,6 +20,7 @@ const TranscriptEditor = ({ match, firebase }) => {
   const [ projectTitle, setProjectTitle ] = useState('');
   const [ transcriptTitle, setTranscriptTitle ] = useState('');
   const [ savedNotification, setSavedNotification ] = useState();
+  const [ showNotification, setShowNotification ] = useState(false);
   const [ mediaType, setMediaType ] = useState('video');
   const [ mediaUrl, setMediaUrl ] = useState('');
 
@@ -35,7 +36,12 @@ const TranscriptEditor = ({ match, firebase }) => {
   useEffect(() => {
     const getTranscript = async () => {
       try {
-        const { media, paragraphs, words, title } = await TranscriptsCollection.getItem(transcriptId);
+        const {
+          media,
+          paragraphs,
+          words,
+          title,
+        } = await TranscriptsCollection.getItem(transcriptId);
         const url = await firebase.storage.storage
           .ref(media.ref)
           .getDownloadURL();
@@ -87,6 +93,10 @@ const TranscriptEditor = ({ match, firebase }) => {
     return item;
   };
 
+  const handleAlertClose = () => {
+    setShowNotification(false);
+  };
+
   const saveButtonHandler = async () => {
     // TODO: decide how to deal with transcript corrections
     // exporting digitalpaperedit in @bbc/react-transcript-editor@latest doesn't give you
@@ -104,32 +114,22 @@ const TranscriptEditor = ({ match, firebase }) => {
 
     try {
       await updateTranscript(transcriptId, data);
+      setShowNotification(true);
       setSavedNotification(
-        <CustomAlert
-          dismissable={ true }
-          variant="success"
-          heading="Transcript saved"
-          message={
-            <p>
-              Transcript: <b>{transcriptTitle}</b> has been saved
-            </p>
-          }
-        />
+        <Alert onClose={ handleAlertClose } dismissible variant="success">
+          <Alert.Heading>Transcript saved</Alert.Heading>
+          Transcript: <b>{transcriptTitle}</b> has been saved
+        </Alert>
       );
     } catch (error) {
       console.error('Error saving transcript::', error);
+      setShowNotification(true);
       setSavedNotification(
-        <CustomAlert
-          dismissable={ true }
-          variant="danger"
-          heading="Error saving transcript"
-          message={
-            <p>
-              There was an error trying to save this transcript:{' '}
-              <b>{transcriptTitle}</b>
-            </p>
-          }
-        />
+        <Alert onClose={ handleAlertClose } dismissible variant="danger">
+          <Alert.Heading>Error saving transcript</Alert.Heading>
+          There was an error trying to save this transcript:{' '}
+          <b>{transcriptTitle}</b>
+        </Alert>
       );
     }
   };
@@ -172,7 +172,7 @@ const TranscriptEditor = ({ match, firebase }) => {
             <br />
           </Col>
         </Row>
-        {savedNotification}
+        {showNotification ? savedNotification : null}
         {transcriptData && (
           <ReactTranscriptEditor
             transcriptData={ transcriptData } // Transcript json


### PR DESCRIPTION
Saved notification does not reappear and does not show the error version of Alert on firestore operations.
We previously did not throw errors when doing operations in Firestore. This meant that we didn't ever get the error Alert / "SavedNotification" when the save operation failed.
We also did not have a state to manage showing of the notifications.

**Is your Pull Request request related to another [issue](https://github.com/bbc/react-transcript-editor/issues) in this repository ?**      
Discovered as part of #107 and #112 

**Describe what the PR does**    
Removing custom alerts, as it wasn't adding much.
Making sure that the notification reappears
Making sure we actually throw the Error upwards, so individual components can handle it as well.


**State whether the PR is ready for review or whether it needs extra work**    
Ready

**Additional context**    
Some side cleaning up for App


<!-- 
## User Story / Context
|As a ...|I want ...|So that ...|
|-|-|-|
|<Who>|<What>|<Why>|

## Acceptance Criteria
- <Criteria to satisfy the PR Issue>

## Definitions of Done
- [ ] Runs locally
- [ ] Runs remotely
- [ ] Test passes
- [ ] Demonstrated
- [ ] Deployed to Cosmos on Test and Live
- [ ] Documentation
  - [ ] Developer Documentation - [repo's README|<link>]
  - [ ] Stakeholder Documentation - [Confluence|<link>]
  - [ ] Operational Documentation - [Runbook|<link>]
- [ ] Peer reviewed by:
-->
