### PR TITLE
Adding improvements to too many useEffect re-renders + calling

### DIFF
--- a/src/Components/PaperEditor/index.js
+++ b/src/Components/PaperEditor/index.js
@@ -21,6 +21,11 @@ const PaperEditor = (props) => {
 
   const [ projectTitle, setProjectTitle ] = useState('');
   const [ paperEditTitle, setPaperEditTitle ] = useState('');
+
+  const [ fetchTranscripts, setFetchTranscripts ] = useState(false);
+  const [ fetchProject, setFetchProject ] = useState(false);
+  const [ fetchPaperEdit, setFetchPaperEdit ] = useState(false);
+
   const [ transcripts, setTranscripts ] = useState();
 
   const [ isTranscriptsShown, setIsTranscriptsShown ] = useState(true);
@@ -38,23 +43,25 @@ const PaperEditor = (props) => {
 
   useEffect(() => {
     const getProject = async () => {
+      setFetchProject(true);
       try {
         const project = await Projects.getItem(projectId);
         setProjectTitle(project.title);
       } catch (e) {
-        console.error('Could not get Project Id: ', papereditId, e);
+        console.error('Could not get Project Id: ', projectId, e);
       }
     };
 
-    if (!transcripts) {
+    if (!projectTitle && !fetchProject) {
       getProject();
     }
 
     return () => {};
-  }, [ Projects, papereditId, projectId, transcripts ]);
+  }, [ Projects, projectTitle, projectId, fetchProject ]);
 
   useEffect(() => {
     const getPaperEdit = async () => {
+      setFetchPaperEdit(true);
       try {
         const paperEdit = await PaperEdits.getItem(papereditId);
         setPaperEditTitle(paperEdit.title);
@@ -63,15 +70,16 @@ const PaperEditor = (props) => {
       }
     };
 
-    if (!transcripts) {
+    if (!paperEditTitle && !fetchPaperEdit) {
       getPaperEdit();
     }
 
     return () => {};
-  }, [ PaperEdits, papereditId, transcripts ]);
+  }, [ PaperEdits, papereditId, fetchPaperEdit, paperEditTitle ]);
 
   useEffect(() => {
     const getTranscripts = async () => {
+      setFetchTranscripts(true);
       try {
         Transcriptions.collectionRef.onSnapshot((snapshot) => {
           setTranscripts(
@@ -109,12 +117,13 @@ const PaperEditor = (props) => {
         console.error('Error getting documents: ', error);
       }
     };
-    if (!transcripts) {
+
+    if (!transcripts && !fetchTranscripts) {
       getTranscripts();
     }
 
     return () => {};
-  }, [ Transcriptions.collectionRef, transcripts ]);
+  }, [ Transcriptions.collectionRef, transcripts, fetchTranscripts ]);
 
   const toggleTranscripts = () => {
     if (isProgramScriptShown) {

--- a/src/Util/gzip/index.js
+++ b/src/Util/gzip/index.js
@@ -1,17 +1,21 @@
 import zlib from 'zlib';
 
 const decompress = (compressed) => {
-  console.log('decompressed');
+  console.time('decompressed');
   const buff = Buffer.from(compressed.toBase64(), 'base64');
   const decompBuff = zlib.gunzipSync(buff);
+  const decompressed = JSON.parse(decompBuff.toString());
+  console.timeEnd('decompressed');
 
-  return JSON.parse(decompBuff.toString());
+  return decompressed;
 };
 
 const compress = (decompressed) => {
-  console.log('compressed');
+  console.time('compressed');
+  const compressed = zlib.gzipSync(JSON.stringify(decompressed));
+  console.timeEnd('compressed');
 
-  return zlib.gzipSync(JSON.stringify(decompressed));
+  return compressed;
 };
 
 export { decompress, compress };


### PR DESCRIPTION
**Is your Pull Request request related to another [issue](https://github.com/bbc/react-transcript-editor/issues) in this repository ?**      
Observed that there are quite a few reloading of data from firestore. Preventing that should improve performance + cost savings.

**Describe what the PR does**    
Checks if fetched, and prevents from multiple reloads. Also added compress / decompression time.

**State whether the PR is ready for review or whether it needs extra work**    
Ready

**Additional context**    
<!-- Add any other context or screenshots about the PR. -->


<!-- 
## User Story / Context
|As a ...|I want ...|So that ...|
|-|-|-|
|<Who>|<What>|<Why>|

## Acceptance Criteria
- <Criteria to satisfy the PR Issue>

## Definitions of Done
- [ ] Runs locally
- [ ] Runs remotely
- [ ] Test passes
- [ ] Demonstrated
- [ ] Deployed to Cosmos on Test and Live
- [ ] Documentation
  - [ ] Developer Documentation - [repo's README|<link>]
  - [ ] Stakeholder Documentation - [Confluence|<link>]
  - [ ] Operational Documentation - [Runbook|<link>]
- [ ] Peer reviewed by:
-->
