### PR TITLE
[fix]: Adds handling for Firefox selections

### DIFF
--- a/src/Components/PaperEditor/ProgrammeScriptContainer/get-data-from-user-selection.js
+++ b/src/Components/PaperEditor/ProgrammeScriptContainer/get-data-from-user-selection.js
@@ -26,8 +26,6 @@ function parseWordElDataset(wordEl) {
    * @returns - an object with start and end time - eg {stat: "23.03", end: "39.61"}
    */
 function getDataFromUserWordsSelection(e) {
-  // https://stackoverflow.com/questions/11300590/how-to-captured-selected-text-range-in-ios-after-text-selection-expansion
-  // https://jsfiddle.net/JasonMore/gWZfb/
   if (!window.getSelection().isCollapsed) {
     const selection = window.getSelection();
     const countSelectedRanges = selection.rangeCount;
@@ -36,7 +34,7 @@ function getDataFromUserWordsSelection(e) {
     if (countSelectedRanges === 1) {
       // Handles IE, Opera, Chrome, Firefox before 3: only one range object in a selection
 
-      const selectedRange = window.getSelection().getRangeAt(0).cloneContents();
+      const selectedRange = selection.getRangeAt(0).cloneContents();
 
       words = selectedRange.querySelectorAll('.words');
     } else if (countSelectedRanges > 1) {

--- a/src/Components/PaperEditor/ProgrammeScriptContainer/get-data-from-user-selection.js
+++ b/src/Components/PaperEditor/ProgrammeScriptContainer/get-data-from-user-selection.js
@@ -29,11 +29,29 @@ function getDataFromUserWordsSelection(e) {
   // https://stackoverflow.com/questions/11300590/how-to-captured-selected-text-range-in-ios-after-text-selection-expansion
   // https://jsfiddle.net/JasonMore/gWZfb/
   if (!window.getSelection().isCollapsed) {
-    const selectedRange = window.getSelection().getRangeAt(0).cloneContents();
+    const selection = window.getSelection();
+    const countSelectedRanges = selection.rangeCount;
+    let words;
 
-    // Seems like this work no matter if the selection is made left to right
-    // or right to left form the user
-    const words = selectedRange.querySelectorAll('.words');
+    if (countSelectedRanges === 1) {
+      // Handles IE, Opera, Chrome, Firefox before 3: only one range object in a selection
+
+      const selectedRange = window.getSelection().getRangeAt(0).cloneContents();
+
+      words = selectedRange.querySelectorAll('.words');
+    } else if (countSelectedRanges > 1) {
+      // Handles Firefox after 3: more than one range object in a selection
+
+      const firstRange = selection.getRangeAt(0);
+      const lastRange = selection.getRangeAt(countSelectedRanges - 1);
+
+      const jointRange = new Range();
+      jointRange.setStartBefore(firstRange.startContainer);
+      jointRange.setEndAfter(lastRange.endContainer);
+
+      const testClone = jointRange.cloneContents();
+      words = testClone.querySelectorAll('.words');
+    }
 
     if (words.length !== 0) {
 
@@ -43,7 +61,7 @@ function getDataFromUserWordsSelection(e) {
         transcriptId: words[0].dataset.transcriptId,
         speaker: words[0].dataset.speaker,
         // words: words
-        words: Array.from(words).map((w) => {return parseWordElDataset(w);})
+        words: Array.from(words).map((w) => { return parseWordElDataset(w); })
       };
     }
     else {
@@ -64,6 +82,7 @@ function getDataFromUserWordsSelection(e) {
       return false;
     }
   }
+  // const selectedRange = window.getSelection().getRangeAt(0).cloneContents();
 
   return false;
 }

--- a/src/Components/PaperEditor/ProgrammeScriptContainer/get-data-from-user-selection.js
+++ b/src/Components/PaperEditor/ProgrammeScriptContainer/get-data-from-user-selection.js
@@ -80,7 +80,6 @@ function getDataFromUserWordsSelection(e) {
       return false;
     }
   }
-  // const selectedRange = window.getSelection().getRangeAt(0).cloneContents();
 
   return false;
 }


### PR DESCRIPTION
**Is your Pull Request request related to another [issue](https://github.com/bbc/react-transcript-editor/issues) in this repository ?**      
<!-- _If so please link to other issues and PRs as appropriate_ -->
#101 - Gets multi-select working for Firefox. 

**Describe what the PR does**    
<!-- _A clear and concise description of what the PR does. Feel free to use bulletpoints and checkboxes if needed [...]_ -->
Allows users to select multiple paragraphs in Firefox (Chrome previously implemented). 

To test:
- [ ] Try multi-select in Firefox. It should show all p's being transferred and preserve word timings.
- [ ] Double-check Chrome to make sure that still works too

**State whether the PR is ready for review or whether it needs extra work**    
<!-- _If you are still working on it and just setting it up for later review, or if it's ready to be reviewed for merging_ -->
Ready for Review

**Additional context**    
<!-- Add any other context or screenshots about the PR. -->
`window.getSelection` in Chrome/Opera/IE/Firefox _before 3_ returns a DocumentFragment with a max of one Range object in `getDataFromUserWordsSelection`, when users make a selection. However, in Firefox later than 3, `window.getSelection` returns multiple Range objects. The code in `getDataFromUserWordSelection` was only pulling using the first Range object, which works in most browsers because only one exists. But it meant multi-select wasn't working in Firefox because each paragraph is essentially processed as its own Range object, so only the first was used. 

So this is basically a super easy fix that took me a week that creates a new Range object using the start points of the first selected range and end point of the last selected range when multiple Ranges are selected (ie, in multi-select in new versions of Firefox). 

More: http://help.dottoro.com/ljikwsqs.php

<!-- 
## User Story / Context
|As a ...|I want ...|So that ...|
|-|-|-|
|<Who>|<What>|<Why>|

## Acceptance Criteria
- <Criteria to satisfy the PR Issue>

## Definitions of Done
- [ ] Runs locally
- [ ] Runs remotely
- [ ] Test passes
- [ ] Demonstrated
- [ ] Deployed to Cosmos on Test and Live
- [ ] Documentation
  - [ ] Developer Documentation - [repo's README|<link>]
  - [ ] Stakeholder Documentation - [Confluence|<link>]
  - [ ] Operational Documentation - [Runbook|<link>]
- [ ] Peer reviewed by:
-->
