### PR TITLE
Paper editor load improvements

### DIFF
--- a/src/Components/PaperEditor/TranscriptsContainer/Paragraphs/Paragraph.js
+++ b/src/Components/PaperEditor/TranscriptsContainer/Paragraphs/Paragraph.js
@@ -38,6 +38,7 @@ const Paragraph = (props) => {
   const getWordWithAnnotations = (word) => {
     const wordEl = (
       <Word
+        key={ `word-${ word.id }-${ word.end }` }
         transcriptId={ transcriptId }
         speaker={ speaker }
         word={ word }
@@ -48,6 +49,7 @@ const Paragraph = (props) => {
     if (word.annotation) {
       return (
         <AnnotationOverlayTrigger
+          key={ `annotation-${ word.annotation.labelId }-${ word.id }-${ word.end }` }
           words={ wordEl }
           labels={ labels }
           annotation={ word.annotation }

--- a/src/Components/PaperEditor/TranscriptsContainer/Paragraphs/index.js
+++ b/src/Components/PaperEditor/TranscriptsContainer/Paragraphs/index.js
@@ -14,12 +14,13 @@ const Paragraphs = (props) => {
     displayParagraphs
   } = props;
 
-  const getParagraphEl = (paragraph, isSearchResult) => {
+  const getParagraphEl = (paragraph, searchResultIndex, isSearchResult) => {
     /**
      * Create a Paragraph containing words, with or without annotation (overlay)
      */
     return (
       <Paragraph
+        key={ `paragraph-${ transcriptId }-${ searchResultIndex }` }
         transcriptId={ transcriptId }
         labels={ labels }
         isSearchResult={ isSearchResult }
@@ -37,7 +38,7 @@ const Paragraphs = (props) => {
   const paragraphEls = paragraphs
     .filter((paragraph, displayIndex) => displayParagraphs[displayIndex])
     .map((paragraph, searchResultIndex) =>
-      getParagraphEl(paragraph, isSearchResults[searchResultIndex])
+      getParagraphEl(paragraph, searchResultIndex, isSearchResults[searchResultIndex])
     );
 
   return <>{paragraphEls}</>;

--- a/src/Components/PaperEditor/TranscriptsContainer/TranscriptTabPane/TranscriptTabContent/index.js
+++ b/src/Components/PaperEditor/TranscriptsContainer/TranscriptTabPane/TranscriptTabContent/index.js
@@ -545,6 +545,7 @@ const TranscriptTabContent = (props) => {
           <Suspense fallback={ <div>Loading...</div> }>
             {annotatedParagraphs ? (
               <Paragraphs
+                key={ `${ transcriptId }-${ mediaRef }` }
                 transcriptId={ transcriptId }
                 paragraphs={ annotatedParagraphs }
                 labels={ labels }

--- a/src/Components/PaperEditor/TranscriptsContainer/TranscriptTabPane/index.js
+++ b/src/Components/PaperEditor/TranscriptsContainer/TranscriptTabPane/index.js
@@ -1,20 +1,26 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Tab from 'react-bootstrap/Tab';
-import TranscriptTabContent from './TranscriptTabContent';
+import { Suspense } from 'react';
+//import TranscriptTabContent from './TranscriptTabContent';
+
+const TranscriptTabContent = React.lazy(() => import('./TranscriptTabContent'));
+
 const TranscriptTabPane = (props) => {
   const { transcriptId, groupedc, media, title, projectId, firebase } = props;
 
   return (
     <Tab.Pane eventKey={ transcriptId }>
-      <TranscriptTabContent
-        projectId={ projectId }
-        transcriptId={ transcriptId }
-        title={ title }
-        groupedc={ groupedc }
-        media={ media }
-        firebase={ firebase }
-      />
+      <Suspense fallback={ <div>Loading Tab </div> }>
+        <TranscriptTabContent
+          projectId={ projectId }
+          transcriptId={ transcriptId }
+          title={ title }
+          groupedc={ groupedc }
+          media={ media }
+          firebase={ firebase }
+        />
+      </Suspense>
     </Tab.Pane>
   );
 };

--- a/src/Components/PaperEditor/TranscriptsContainer/index.js
+++ b/src/Components/PaperEditor/TranscriptsContainer/index.js
@@ -9,8 +9,10 @@ import PropTypes from 'prop-types';
 import { withAuthorization } from '../../Session';
 import TranscriptNavItem from './TranscriptNavItem';
 import TranscriptTabPane from './TranscriptTabPane';
+import { useState, useEffect } from 'react';
 
 const TranscriptsContainer = ({ transcripts, projectId, firebase }) => {
+  const [ activeKey, setActiveKey ] = useState();
   const transcriptsElNav = transcripts.map((transcript) => (
     <TranscriptNavItem
       key={ transcript.id }
@@ -19,6 +21,7 @@ const TranscriptsContainer = ({ transcripts, projectId, firebase }) => {
       status={ transcript.status }
     />
   ));
+
   const transcriptsElTab = transcripts.map((transcript) => (
     <TranscriptTabPane
       key={ transcript.id }
@@ -30,42 +33,54 @@ const TranscriptsContainer = ({ transcripts, projectId, firebase }) => {
       firebase={ firebase }
     />
   ));
-  const getDefaultActiveKey = () => {
-    const doneItem = transcripts.find(transcript => transcript.status === 'done');
-    if (doneItem) {
-      return doneItem.id;
-    } else {
-      return 'first';
+
+  useEffect(() => {
+    const getDefaultActiveKey = () => {
+      const transcript = transcripts.find(t => t.status === 'done');
+      if (transcript) {
+        setActiveKey(transcript.id);
+      }
+    };
+    if (transcripts) {
+      getDefaultActiveKey();
     }
-  };
+
+    return () => {
+      setActiveKey('first');
+    };
+  }, [ transcripts ]);
 
   return (
     <>
-      <Tab.Container
-        defaultActiveKey={ getDefaultActiveKey() }
-      >
-        <Row>
-          <Col sm={ 3 }>
-            <h2
-              className={ [ 'text-truncate', 'text-muted' ].join(' ') }
-              title={ 'Transcripts' }
-            >
-              Transcripts
-            </h2>
-            <hr />
+      {transcripts && activeKey ?
+        <Tab.Container
+          defaultActiveKey={ activeKey }
+        >
+          <Row>
+            <Col sm={ 3 }>
+              <h2
+                className={ [ 'text-truncate', 'text-muted' ].join(' ') }
+                title={ 'Transcripts' }
+              >
+                Transcripts
+              </h2>
+              <hr />
 
-            <Nav variant="pills" className="flex-column">
-              {transcriptsElNav}
-            </Nav>
-          </Col>
-          <Col sm={ 9 }>
-            <Tab.Content>
-              {transcriptsElTab}
-            </Tab.Content>
-          </Col>
-        </Row>
-      </Tab.Container>
+              <Nav variant="pills" className="flex-column">
+                {transcriptsElNav}
+              </Nav>
+            </Col>
+            <Col sm={ 9 }>
+              <Tab.Content>
+                {transcriptsElTab}
+              </Tab.Content>
+            </Col>
+          </Row>
+        </Tab.Container> :
+        null
+      }
     </>
+
   );
 };
 

--- a/src/Components/PaperEditor/index.js
+++ b/src/Components/PaperEditor/index.js
@@ -175,16 +175,13 @@ const PaperEditor = (props) => {
   }
 
   let ProgrammeScriptEl = null;
-  if (transcripts) {
-    ProgrammeScriptEl = (
-      <ProgrammeScriptContainer
-        projectId={ projectId }
-        papereditId={ papereditId }
-        transcripts={ transcripts }
-        videoHeight={ videoHeight }
-      />
-    );
-  }
+  ProgrammeScriptEl = (
+    <ProgrammeScriptContainer
+      projectId={ projectId }
+      papereditId={ papereditId }
+      videoHeight={ videoHeight }
+    />
+  );
 
   const transcriptsColumn = (el) => {
     const display = isTranscriptsShown ? 'block' : 'none';
@@ -277,9 +274,10 @@ const PaperEditor = (props) => {
 };
 
 PaperEditor.propTypes = {
-  match: PropTypes.any,
-  videoHeight: PropTypes.any,
   firebase: PropTypes.any,
+  match: PropTypes.any,
+  trackEvent: PropTypes.func,
+  videoHeight: PropTypes.any
 };
 
 const condition = (authUser) => !!authUser;

--- a/src/Components/Session/withAuthorization.js
+++ b/src/Components/Session/withAuthorization.js
@@ -12,23 +12,24 @@ import * as ROUTES from '../../constants/routes';
 const withAuthorization = condition => Component => {
 
   const WithAuthorization = props => {
+    const { firebase, history, setAnalyticsUserId } = { ...props };
 
     useEffect(() => {
-      const listener = props.firebase.onAuthUserListener(
+      const listener = firebase.onAuthUserListener(
         authUser => {
           if (!condition(authUser)) {
-            props.history.push(ROUTES.SIGN_IN);
+            history.push(ROUTES.SIGN_IN);
           } else {
-            props.setAnalyticsUserId(`${ authUser.uid } ${ authUser.email }`);
+            setAnalyticsUserId(`${ authUser.uid } ${ authUser.email }`);
           }
         },
-        () => props.history.push(ROUTES.SIGN_IN)
+        () => history.push(ROUTES.SIGN_IN)
       );
 
       return () => {
         listener();
       };
-    }, [ props.firebase, props.history, props.setAnalyticsUserId ]);
+    }, [ firebase, history, setAnalyticsUserId, ]);
 
     return (
       <AuthUserContext.Consumer>
@@ -39,7 +40,8 @@ const withAuthorization = condition => Component => {
 
   WithAuthorization.propTypes = {
     firebase: PropTypes.any,
-    history: PropTypes.any
+    history: PropTypes.any,
+    setAnalyticsUserId: PropTypes.func
   };
 
   return compose(withRouter, withFirebase, withAnalytics)(WithAuthorization);


### PR DESCRIPTION
**Is your Pull Request request related to another [issue](https://github.com/bbc/react-transcript-editor/issues) in this repository ?**      
<!-- _If so please link to other issues and PRs as appropriate_ -->


**Describe what the PR does**    
<!-- _A clear and concise description of what the PR does. Feel free to use bulletpoints and checkboxes if needed [...]_ -->

- added save button (disabled when saved)
- moved transcript loading to the paper editor tab from the parent. The parent was loading all the transcripts before it passed it to the paper editor component, which made everything slower. The transcript loading only happens if the paper edits elements contain media (excluding notes etc.)
- disabled share button until media content is loaded. This helps with making sure that all the data is there before a user tries to export

Bug fixes
- [x] the videos were no longer updating on updating the elements.
- [ ] programme script collapse is no longer working

**State whether the PR is ready for review or whether it needs extra work**    
<!-- _If you are still working on it and just setting it up for later review, or if it's ready to be reviewed for merging_ -->

**Additional context**    
<!-- Add any other context or screenshots about the PR. -->


<!-- 
## User Story / Context
|As a ...|I want ...|So that ...|
|-|-|-|
|<Who>|<What>|<Why>|

## Acceptance Criteria
- <Criteria to satisfy the PR Issue>

## Definitions of Done
- [ ] Runs locally
- [ ] Runs remotely
- [ ] Test passes
- [ ] Demonstrated
- [ ] Deployed to Cosmos on Test and Live
- [ ] Documentation
  - [ ] Developer Documentation - [repo's README|<link>]
  - [ ] Stakeholder Documentation - [Confluence|<link>]
  - [ ] Operational Documentation - [Runbook|<link>]
- [ ] Peer reviewed by:
-->
![Screenshot 2021-02-28 at 13 37 43](https://user-images.githubusercontent.com/8188418/109420557-0d190e80-79cb-11eb-9dc4-4dccba2fec64.png)
