### PR TITLE
Label Modal doesn't automatically close once the label is created

### DIFF
--- a/src/Components/PaperEditor/TranscriptsContainer/TranscriptTabPane/index.js
+++ b/src/Components/PaperEditor/TranscriptsContainer/TranscriptTabPane/index.js
@@ -7,7 +7,7 @@ import { Suspense } from 'react';
 const TranscriptTabContent = React.lazy(() => import('./TranscriptTabContent'));
 
 const TranscriptTabPane = (props) => {
-  const { transcriptId, groupedc, media, title, projectId, firebase } = props;
+  const { transcriptId, groupedc, media, title, projectId, firebase, trackEvent } = props;
 
   return (
     <Tab.Pane eventKey={ transcriptId }>
@@ -19,6 +19,7 @@ const TranscriptTabPane = (props) => {
           groupedc={ groupedc }
           media={ media }
           firebase={ firebase }
+          trackEvent={ trackEvent }
         />
       </Suspense>
     </Tab.Pane>
@@ -32,6 +33,7 @@ TranscriptTabPane.propTypes = {
   projectId: PropTypes.any,
   title: PropTypes.any,
   transcriptId: PropTypes.any,
+  trackEvent: PropTypes.func
 };
 
 export default TranscriptTabPane;

--- a/src/Components/PaperEditor/TranscriptsContainer/index.js
+++ b/src/Components/PaperEditor/TranscriptsContainer/index.js
@@ -11,7 +11,7 @@ import TranscriptNavItem from './TranscriptNavItem';
 import TranscriptTabPane from './TranscriptTabPane';
 import { useState, useEffect } from 'react';
 
-const TranscriptsContainer = ({ transcripts, projectId, firebase }) => {
+const TranscriptsContainer = ({ transcripts, projectId, firebase, trackEvent }) => {
   const [ activeKey, setActiveKey ] = useState();
   const transcriptsElNav = transcripts.map((transcript) => (
     <TranscriptNavItem
@@ -31,6 +31,7 @@ const TranscriptsContainer = ({ transcripts, projectId, firebase }) => {
       title={ transcript.title }
       projectId={ projectId }
       firebase={ firebase }
+      trackEvent={ trackEvent }
     />
   ));
 
@@ -88,6 +89,7 @@ TranscriptsContainer.propTypes = {
   projectId: PropTypes.any,
   transcripts: PropTypes.any,
   firebase: PropTypes.any,
+  trackEvent: PropTypes.func
 };
 
 const condition = (authUser) => !!authUser;

--- a/src/Components/Projects/index.js
+++ b/src/Components/Projects/index.js
@@ -172,6 +172,7 @@ Projects.propTypes = {
   firebase: PropTypes.shape({
     onAuthUserListener: PropTypes.func,
   }),
+  trackEvent: PropTypes.func
 };
 
 const condition = (authUser) => !!authUser;

--- a/src/Components/Workspace/Transcripts/index.js
+++ b/src/Components/Workspace/Transcripts/index.js
@@ -208,6 +208,7 @@ const Transcripts = ({ projectId, firebase, trackEvent }) => {
 Transcripts.propTypes = {
   projectId: PropTypes.any,
   firebase: PropTypes.any,
+  trackEvent: PropTypes.func
 };
 
 const condition = (authUser) => !!authUser;

--- a/src/Components/Workspace/index.js
+++ b/src/Components/Workspace/index.js
@@ -87,7 +87,8 @@ WorkspaceView.propTypes = {
     params: PropTypes.shape({
       projectId: PropTypes.any
     })
-  })
+  }),
+  trackEvent: PropTypes.func
 };
 const condition = authUser => !!authUser;
 export default withAuthorization(condition)(WorkspaceView);


### PR DESCRIPTION
**Is your Pull Request request related to another [issue](https://github.com/bbc/react-transcript-editor/issues) in this repository ?**      

Bug fix - label creation should have closed the modal automatically, but because `trackEvent` was not defined (not passed from parent component that had the analytics context), when it was called after label creation, it threw an exception.


**Describe what the PR does**    
- [x] update components to have access to trackEvent where they did not have access to analytics context.
- [x] update props 


**State whether the PR is ready for review or whether it needs extra work**    
Ready for review

**Additional context**    
<!-- Add any other context or screenshots about the PR. -->


<!-- 
## User Story / Context
|As a ...|I want ...|So that ...|
|-|-|-|
|<Who>|<What>|<Why>|

## Acceptance Criteria
- <Criteria to satisfy the PR Issue>

## Definitions of Done
- [ ] Runs locally
- [ ] Runs remotely
- [ ] Test passes
- [ ] Demonstrated
- [ ] Deployed to Cosmos on Test and Live
- [ ] Documentation
  - [ ] Developer Documentation - [repo's README|<link>]
  - [ ] Stakeholder Documentation - [Confluence|<link>]
  - [ ] Operational Documentation - [Runbook|<link>]
- [ ] Peer reviewed by:
-->
