### PR TITLE
FCP integration – src value fix

### DIFF
--- a/src/Components/PaperEditor/ProgrammeScriptContainer/ExportDropdown/edl.js
+++ b/src/Components/PaperEditor/ProgrammeScriptContainer/ExportDropdown/edl.js
@@ -8,7 +8,7 @@ const formatToEDLEvent = (transcript, element) => {
     reelName: transcript.metadata
       ? transcript.metadata.reelName
       : defaultReelName,
-    clipName: `${ transcript.title.replace(/\s+/g, '%20') }`,
+    clipName: `${ encodeURIComponent(transcript.title) }`,
     // TODO: frameRate should be pulled from the clips in the sequence
     // Changing to 24 fps because that is the frame rate of the ted talk examples from youtube
     // but again frameRate should not be hard coded

--- a/src/Components/PaperEditor/ProgrammeScriptContainer/ExportDropdown/edl.js
+++ b/src/Components/PaperEditor/ProgrammeScriptContainer/ExportDropdown/edl.js
@@ -8,7 +8,7 @@ const formatToEDLEvent = (transcript, element) => {
     reelName: transcript.metadata
       ? transcript.metadata.reelName
       : defaultReelName,
-    clipName: `${ transcript.clipName }`,
+    clipName: `${ transcript.title.replace(/\s+/g, '%20') }`,
     // TODO: frameRate should be pulled from the clips in the sequence
     // Changing to 24 fps because that is the frame rate of the ted talk examples from youtube
     // but again frameRate should not be hard coded


### PR DESCRIPTION
Work related to #153 

This PR fixes the fcpxml issue where the src attribute within the [asset element](https://developer.apple.com/documentation/professional_video_applications/fcpxml_reference/asset) was `undefined`, therefore FCP was unable to link the correct media file(s).

For the fcpxml to work, the user has to:
1. Make sure all media files are downloaded
2. Export fcpxml from DPE into the same directory as the respective media files
3. Open fcpxml with FCP

## Acceptance Criteria (without access to FCP)
1. Make sure all media files are downloaded
2. Export fcpxml
3. Open fcpxml with any text editor/ide 
4. Observe that the src attribute within each <asset> element is populated with the correct file name.
5. Any whitespace within the file name is escaped with `%20`

**Note:** There is more work to be done for this FCP integration work. Investigation into FCP user workflows is required before this can fully completed. The work done in this PR is to allow some basic functionality.