### PR TITLE
Expired media

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,8 +237,8 @@ firebase functions:config:get > .runtimeconfig.json
 ```
 firebase functions:shell
 ```
-4. Call the function you would like to test e.g. type `dpeCronExpiredMediaChecker()`
-5. BEWARE!!! Running these functions will really affect files in the Firestore, so tread carefully!
+4. BEWARE!!! Running functions locally will really affect files in the Firestore, so tread carefully!
+5. Call the function you would like to test e.g. run `dpeCronExpiredMediaChecker()`
 
 See [here](https://firebase.google.com/docs/functions/local-emulator) for more info on running functions locally.
 

--- a/README.md
+++ b/README.md
@@ -219,7 +219,9 @@ Node version is set in node version manager
 
 Use node v8 in Functions directory.
 
-Developing is a lot easier if you have your **local emulator** set up. Here is how to run the firebase functions locally:
+Developing is a lot easier if you have your **local emulator** set up. 
+
+### Running Firebase functions locally:
 
 1. Set up admin credentials for emulated functions via the [service account](https://console.cloud.google.com/iam-admin/serviceaccounts/details/102625058144632397517/keys?authuser=1&folder=&organizationId=&project=newslabs-dev-aa20&supportedpurview=project )
 2. Make sure you are in the `newslab-dev` project and click `Add key`
@@ -237,6 +239,8 @@ firebase functions:shell
 ```
 4. Call the function you would like to test e.g. type `dpeCronExpiredMediaChecker()`
 5. BEWARE!!! Running these functions will really affect files in the Firestore, so tread carefully!
+
+See [here](https://firebase.google.com/docs/functions/local-emulator) for more info on running functions locally.
 
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -219,16 +219,25 @@ Node version is set in node version manager
 
 Use node v8 in Functions directory.
 
-Developing is a lot easier if you have your **local emulator** set up.
+Developing is a lot easier if you have your **local emulator** set up. Here is how to run the firebase functions locally:
 
-1. Follow the instructions
-   [here](https://firebase.google.com/docs/functions/local-emulator#set_up_admin_credentials_optional) to get the admin credentials.
-2. You need to save this as `gcp-credentials.json` and keep it in your
+1. Set up admin credentials for emulated functions via the [service account](https://console.cloud.google.com/iam-admin/serviceaccounts/details/102625058144632397517/keys?authuser=1&folder=&organizationId=&project=newslabs-dev-aa20&supportedpurview=project )
+2. Make sure you are in the `newslab-dev` project and click `Add key`
+3. You need to save this as `gcp-credentials.json` and keep it in your
    `digital-paper-edit-firebase/functions` folder.
-3. Run `./start_firebase_shell` in functions folder. This should start the emulator running in your terminal window.
-4. Call the function e.g. type `expiredMediaChecker()`
-5. BEWARE!!! Running these functions will affect Firebase files, so tread carefully!
-   <!-- TODO: Setup eslint in express server -->
+4. cd to your `digital-paper-edit-firebase/functions` folder.
+5. run the following commands
+```
+export GOOGLE_APPLICATION_CREDENTIALS="gcp-credentials.json"
+firebase functions:config:get > .runtimeconfig.json
+```
+3. Then to start the emulator in your terminal window, run 
+```
+firebase functions:shell
+```
+4. Call the function you would like to test e.g. type `dpeCronExpiredMediaChecker()`
+5. BEWARE!!! Running these functions will really affect files in the Firestore, so tread carefully!
+
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -222,11 +222,12 @@ Use node v8 in Functions directory.
 Developing is a lot easier if you have your **local emulator** set up.
 
 1. Follow the instructions
-   [here](https://firebase.google.com/docs/functions/local-2.
-   emulator#set_up_admin_credentials_optional) to get the admin credentials.
+   [here](https://firebase.google.com/docs/functions/local-emulator#set_up_admin_credentials_optional) to get the admin credentials.
 2. You need to save this as `gcp-credentials.json` and keep it in your
    `digital-paper-edit-firebase/functions` folder.
-3. Run `./start_firebase_shell` in functions folder.
+3. Run `./start_firebase_shell` in functions folder. This should start the emulator running in your terminal window.
+4. Call the function e.g. type `expiredMediaChecker()`
+5. BEWARE!!! Running these functions will affect Firebase files, so tread carefully!
    <!-- TODO: Setup eslint in express server -->
 
 ## Documentation

--- a/functions/dpeCronExpiredMediaChecker/index.js
+++ b/functions/dpeCronExpiredMediaChecker/index.js
@@ -4,37 +4,60 @@ const isDeletableContentType = (contentType) => {
   return contentType ? contentType.includes('video') || contentType.includes('audio') : false;
 };
 
-const dpeCronExpiredMediaChecker = async (bucket, admin) => {
-  bucket.getFiles().then((data) => {
-    const files = data[0];
+const deleteExpiredFile = async (file, admin) => {
+  await file.delete();
+  await updateTranscription(admin, file.metadata.metadata.id, file.metadata.metadata.projectId, {
+    status: 'expired',
+    message: 'Media older than 60 days',
+  });
+};
 
-    files.forEach((file) => {
+const checkForExpiredContent = async (allFiles, admin) => {
+  // eslint-disable-next-line consistent-return
+  allFiles.forEach(async (file) => {
+    try {
       const dateCreated = new Date(file.metadata.timeCreated);
-
       const expiryDate = new Date(dateCreated);
       expiryDate.setDate(dateCreated.getDate() + 60);
 
       if (Date.now() >= expiryDate && isDeletableContentType(file.metadata.contentType)) {
-        file.delete();
-        updateTranscription(admin, file.metadata.metadata.id, file.metadata.metadata.projectId, {
-          status: 'expired',
-          message: 'Media older than 60 days',
-        });
+        await deleteExpiredFile(file, admin);
 
-        console.log(`Expired media was deleted:
-          originalName: ${ file.metadata.metadata.originalName }
-          timeCreated: ${ file.metadata.timeCreated }
-          filePath: ${ file.metadata.name }
-          id: ${ file.metadata.metadata.id }
-          userId: ${ file.metadata.metadata.userId }
-          projectId: ${ file.metadata.metadata.projectId }`);
+        return console.log(`[IN PROGRESS] Expired media was deleted:
+            originalName: ${ file.metadata.metadata.originalName }
+            timeCreated: ${ file.metadata.timeCreated }
+            filePath: ${ file.metadata.name }
+            id: ${ file.metadata.metadata.id }
+            userId: ${ file.metadata.metadata.userId }
+            projectId: ${ file.metadata.metadata.projectId }`);
       }
-    });
+      else {
+        return console.log(`[IN PROGRESS] Ignoring media - not expired:
+            originalName: ${ file.metadata.metadata.originalName }
+            timeCreated: ${ file.metadata.timeCreated }
+            filePath: ${ file.metadata.name }
+            id: ${ file.metadata.metadata.id }
+            userId: ${ file.metadata.metadata.userId }
+            projectId: ${ file.metadata.metadata.projectId }`);
+      }
+    } catch {(error) => {
+      return console.log(`[ERROR]: Unable to delete file ${ file.metadata.metadata.originalName ? file.metadata.metadata.originalName : '' }: `, error);
+    };}
+  });};
 
-    return;
-  }).catch(error => {
-    return console.log(`Files could not be retreived ${ error }`);
+const dpeCronExpiredMediaChecker = async (bucket, admin) => {
+  console.log('[START] Checking for expired media files...');
+  try {
+    const allFiles = await bucket.getFiles();
+    await checkForExpiredContent(allFiles[0], admin);
+  }
+  catch {(error => {
+    return console.log(`[ERROR] Files could not be deleted ${ error }`);
   });
+
+  }
+
+  return console.log('[COMPLETE] Deleted expired media content');
 };
 
 exports.createHandler = async (bucket, admin) => {

--- a/functions/dpeCronExpiredMediaChecker/index.js
+++ b/functions/dpeCronExpiredMediaChecker/index.js
@@ -17,7 +17,7 @@ const dpeCronExpiredMediaChecker = (bucket, admin) => {
       if (
         Date.now() >= expiryDate &&
         isDeletableContentType(file.metadata.contentType)
-        // && file.metadata.metadata.id === "zgBSIGwTvqJjlbto5nb2" // UNCOMMENT TO SAFELY TEST FILE DELETION/UPDATE TRANSCRIPTION STATUS
+        // && file.metadata.metadata.id === 'kHN7t5yCJNpPwbODfIH5' // UNCOMMENT TO SAFELY TEST FILE DELETION/UPDATE TRANSCRIPTION STATUS
         ) {
 
         // file.delete();

--- a/functions/dpeCronExpiredMediaChecker/index.js
+++ b/functions/dpeCronExpiredMediaChecker/index.js
@@ -63,15 +63,15 @@ const dpeCronExpiredMediaChecker = async (bucket, admin) => {
   try {
     const expiredContent = checkForExpiredContent(allFiles, admin);
     if (expiredContent.length > 0) {
-      await Promise.all(expiredContent);
+      return await Promise.all(expiredContent);
     }
     functions.logger.log('[COMPLETE] Deleted expired media content ✅');
+    return Promise.resolve();
   }
   catch (error) {
     functions.logger.log(`[ERROR] Files could not be deleted`, error );
-    return error;
+    return Promise.reject(error);
   }
-  return true;
 };
 
 exports.createHandler = async (bucket, admin) => {

--- a/functions/dpeCronExpiredMediaChecker/index.js
+++ b/functions/dpeCronExpiredMediaChecker/index.js
@@ -6,58 +6,51 @@ const isDeletableContentType = (contentType) => {
 
 const deleteExpiredFile = async (file, admin) => {
   await file.delete();
-  await updateTranscription(admin, file.metadata.metadata.id, file.metadata.metadata.projectId, {
-    status: 'expired',
-    message: 'Media older than 60 days',
-  });
+  const transcriptId = file.metadata.metadata.id;
+  if (transcriptId) {
+    await updateTranscription(admin, transcriptId, file.metadata.metadata.projectId, {
+      status: 'expired',
+      message: 'Media older than 60 days',
+    });
+  }
 };
 
 const checkForExpiredContent = async (allFiles, admin) => {
+  const daysUntilExpiry = 60;
+  let filePath = '';
   // eslint-disable-next-line consistent-return
   allFiles.forEach(async (file) => {
     try {
       const dateCreated = new Date(file.metadata.timeCreated);
       const expiryDate = new Date(dateCreated);
-      expiryDate.setDate(dateCreated.getDate() + 60);
+      expiryDate.setDate(dateCreated.getDate() + daysUntilExpiry);
+      filePath = file.metadata.name;
+      const transcriptFilePath = `projects/${ file.metadata.metadata.projectId }/transcripts/${ file.metadata.metadata.id }`;
 
       if (Date.now() >= expiryDate && isDeletableContentType(file.metadata.contentType)) {
         await deleteExpiredFile(file, admin);
 
-        return console.log(`[IN PROGRESS] Expired media was deleted:
-            originalName: ${ file.metadata.metadata.originalName }
-            timeCreated: ${ file.metadata.timeCreated }
-            filePath: ${ file.metadata.name }
-            id: ${ file.metadata.metadata.id }
-            userId: ${ file.metadata.metadata.userId }
-            projectId: ${ file.metadata.metadata.projectId }`);
+        return console.log(`[IN PROGRESS] Expired media is being deleted:
+        filePath: ${ filePath }
+        transcriptFilePath: ${ transcriptFilePath }`);
       }
-      else {
-        return console.log(`[IN PROGRESS] Ignoring media - not expired:
-            originalName: ${ file.metadata.metadata.originalName }
-            timeCreated: ${ file.metadata.timeCreated }
-            filePath: ${ file.metadata.name }
-            id: ${ file.metadata.metadata.id }
-            userId: ${ file.metadata.metadata.userId }
-            projectId: ${ file.metadata.metadata.projectId }`);
-      }
-    } catch {(error) => {
-      return console.log(`[ERROR]: Unable to delete file ${ file.metadata.metadata.originalName ? file.metadata.metadata.originalName : '' }: `, error);
-    };}
-  });};
+    } catch (error) {
+      return console.log(`[ERROR]: Unable to delete file ${ filePath }: `, error);
+    }
+  });
+};
 
 const dpeCronExpiredMediaChecker = async (bucket, admin) => {
   console.log('[START] Checking for expired media files...');
   try {
     const allFiles = await bucket.getFiles();
     await checkForExpiredContent(allFiles[0], admin);
+
+    return console.log('[COMPLETE] Deleted expired media content ✅');
   }
-  catch {(error => {
+  catch (error) {
     return console.log(`[ERROR] Files could not be deleted ${ error }`);
-  });
-
   }
-
-  return console.log('[COMPLETE] Deleted expired media content');
 };
 
 exports.createHandler = async (bucket, admin) => {

--- a/functions/expiredMediaChecker/index.js
+++ b/functions/expiredMediaChecker/index.js
@@ -3,38 +3,45 @@ const { updateTranscription } = require("../sttChecker");
 const expiredMediaChecker = (bucket, admin) => {
   bucket.getFiles().then((data) => {
     const files = data[0];
+
     files.forEach((file) => {
       const dateCreated = new Date(file.metadata.timeCreated);
+
       let expiryDate = new Date(dateCreated);
       expiryDate.setDate(dateCreated.getDate() + 60);
+
       const isDeletableContentType = (contentType) => {
+        let isDeletable = false;
         if (contentType !== undefined) {
-          if (contentType.includes("video") || contentType.includes("audio")) {
-            return true;
-          }
+          isDeletable = contentType.includes("video") || contentType.includes("audio");
         }
-        return false;
+        return isDeletable;
       }
+
       if (
         Date.now() >= expiryDate &&
-        isDeletableContentType(file.metadata.contentType)) {
-        file.delete();
-        updateTranscription(admin, file.metadata.metadata.id, file.metadata.metadata.projectId, {
-          status: "expired",
-          message: "Media older than 60 days",
-        });
+        isDeletableContentType(file.metadata.contentType)
+        // && file.metadata.metadata.id === "zgBSIGwTvqJjlbto5nb2" // UNCOMMENT TO SAFELY TEST FILE DELETION/UPDATE TRANSCRIPTION STATUS
+        ) {
+
+        // file.delete();
+        // updateTranscription(admin, file.metadata.metadata.id, file.metadata.metadata.projectId, {
+        //   status: "expired",
+        //   message: "Media older than 60 days",
+        // });
 
         console.log(`Expired media was deleted:
-          userId: ${ file.metadata.metadata.userId }
-          id: ${ file.metadata.metadata.id }
-          projectId: ${ file.metadata.metadata.projectId }
           originalName: ${ file.metadata.metadata.originalName }
-          folder: ${ file.metadata.metadata.folder }`);
+          timeCreated: ${ file.metadata.timeCreated }
+          filePath: ${ file.metadata.name }
+          id: ${ file.metadata.metadata.id }
+          userId: ${ file.metadata.metadata.userId }
+          projectId: ${ file.metadata.metadata.projectId }`);
       }
     })
-    return null;
+    return;
   }).catch(error => {
-    console.log(`Files could not be retreived ${ error }`);
+    return console.log(`Files could not be retreived ${ error }`);
   })
 }
 

--- a/functions/expiredMediaChecker/index.js
+++ b/functions/expiredMediaChecker/index.js
@@ -1,0 +1,43 @@
+const { updateTranscription } = require("../sttChecker");
+
+const expiredMediaChecker = (bucket, admin) => {
+  bucket.getFiles().then((data) => {
+    const files = data[0];
+    files.forEach((file) => {
+      const dateCreated = new Date(file.metadata.timeCreated);
+      let expiryDate = new Date(dateCreated);
+      expiryDate.setDate(dateCreated.getDate() + 60);
+      const isDeletableContentType = (contentType) => {
+        if (contentType !== undefined) {
+          if (contentType.includes("video") || contentType.includes("audio")) {
+            return true;
+          }
+        }
+        return false;
+      }
+      if (
+        Date.now() >= expiryDate &&
+        isDeletableContentType(file.metadata.contentType)) {
+        file.delete();
+        updateTranscription(admin, file.metadata.metadata.id, file.metadata.metadata.projectId, {
+          status: "expired",
+          message: "Media older than 60 days",
+        });
+
+        console.log(`Expired media was deleted:
+          userId: ${ file.metadata.metadata.userId }
+          id: ${ file.metadata.metadata.id }
+          projectId: ${ file.metadata.metadata.projectId }
+          originalName: ${ file.metadata.metadata.originalName }
+          folder: ${ file.metadata.metadata.folder }`);
+      }
+    })
+    return null;
+  }).catch(error => {
+    console.log(`Files could not be retreived ${ error }`);
+  })
+}
+
+exports.createHandler = async (bucket, admin) => {
+  await expiredMediaChecker(bucket, admin);
+};

--- a/functions/expiredMediaChecker/index.js
+++ b/functions/expiredMediaChecker/index.js
@@ -1,6 +1,10 @@
 const { updateTranscription } = require("../sttChecker");
 
-const expiredMediaChecker = (bucket, admin) => {
+const isDeletableContentType = (contentType) => {
+  return contentType ? contentType.includes("video") || contentType.includes("audio") : false;
+}
+
+const dpeCronExpiredMediaChecker = (bucket, admin) => {
   bucket.getFiles().then((data) => {
     const files = data[0];
 
@@ -9,14 +13,6 @@ const expiredMediaChecker = (bucket, admin) => {
 
       let expiryDate = new Date(dateCreated);
       expiryDate.setDate(dateCreated.getDate() + 60);
-
-      const isDeletableContentType = (contentType) => {
-        let isDeletable = false;
-        if (contentType !== undefined) {
-          isDeletable = contentType.includes("video") || contentType.includes("audio");
-        }
-        return isDeletable;
-      }
 
       if (
         Date.now() >= expiryDate &&
@@ -46,5 +42,5 @@ const expiredMediaChecker = (bucket, admin) => {
 }
 
 exports.createHandler = async (bucket, admin) => {
-  await expiredMediaChecker(bucket, admin);
+  await dpeCronExpiredMediaChecker(bucket, admin);
 };

--- a/functions/index.js
+++ b/functions/index.js
@@ -53,10 +53,10 @@ exports.dpeCronSTTJobChecker = functions
     sttChecker.createHandler(admin, config.aws.api.transcriber, context)
   );
 
-exports.expiredMediaChecker = functions
+exports.dpeCronExpiredMediaChecker = functions
   .pubsub.schedule("every 24 hours")
   .onRun(() => {
-    expiredMediaChecker.createHandler(bucket, admin);
+    dpeCronExpiredMediaChecker.createHandler(bucket, admin);
   });
 
 // For migration of DB

--- a/functions/index.js
+++ b/functions/index.js
@@ -6,6 +6,7 @@ const inventoryChecker = require("./inventoryChecker");
 const audioStripper = require("./audioStripper");
 const awsUploader = require("./awsUploader");
 const sttChecker = require("./sttChecker");
+const expiredMediaChecker = require("./expiredMediaChecker");
 
 // Was run as a migration task
 // const compressData = require("./compressData")
@@ -51,6 +52,12 @@ exports.dpeCronSTTJobChecker = functions
   .onRun((context) =>
     sttChecker.createHandler(admin, config.aws.api.transcriber, context)
   );
+
+exports.expiredMediaChecker = functions
+  .pubsub.schedule("every 24 hours")
+  .onRun(() => {
+    expiredMediaChecker.createHandler(bucket, admin);
+  });
 
 // For migration of DB
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -56,9 +56,9 @@ exports.dpeCronSTTJobChecker = functions
 exports.dpeCronExpiredMediaChecker = functions
   .runWith(maxRuntimeOpts)
   .pubsub.schedule("every 24 hours")
-  .onRun(() => {
-    dpeCronExpiredMediaChecker.createHandler(bucket, admin);
-  });
+  .onRun(() =>
+    dpeCronExpiredMediaChecker.createHandler(bucket, admin)
+  );
 
 // For migration of DB
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -6,7 +6,7 @@ const inventoryChecker = require("./inventoryChecker");
 const audioStripper = require("./audioStripper");
 const awsUploader = require("./awsUploader");
 const sttChecker = require("./sttChecker");
-const expiredMediaChecker = require("./expiredMediaChecker");
+const dpeCronExpiredMediaChecker = require("./dpeCronExpiredMediaChecker");
 
 // Was run as a migration task
 // const compressData = require("./compressData")

--- a/functions/index.js
+++ b/functions/index.js
@@ -54,6 +54,7 @@ exports.dpeCronSTTJobChecker = functions
   );
 
 exports.dpeCronExpiredMediaChecker = functions
+  .runWith(maxRuntimeOpts)
   .pubsub.schedule("every 24 hours")
   .onRun(() => {
     dpeCronExpiredMediaChecker.createHandler(bucket, admin);

--- a/functions/sttChecker/index.js
+++ b/functions/sttChecker/index.js
@@ -212,3 +212,5 @@ const sttCheckRunner = async (admin, config, execTimestamp) => {
 exports.createHandler = async (admin, config, context) => {
   await sttCheckRunner(admin, config, context.timestamp);
 };
+
+exports.updateTranscription = updateTranscription;


### PR DESCRIPTION
fixes #195 

**Describe what the PR does**    
* A scheduled function runs daily to check for expired media
* Media content that was uploaded to Firestore 60 days or over should be deleted
* The status field of the transcript document the deleted file belongs to in Firestore is set to "expired"

**State whether the PR is ready for review or whether it needs extra work**    
Ready for review. Need to edit code after review as some bits were adjusted specifically to allow for testing.


## Acceptance Criteria

1. Follow README functions section (line 224-230) within the expired-media branch
2. Run `dpeCronExpiredMediaChecker()` in the firebase shell. (The lines that delete files and update transcripts have been commented out for now)
3. Observe the log listing the expired files (they haven't really been deleted though!)
4. Ensure the timeCreated is over 60 days ago.
 To test deleting a file and updating transcript status:
1. uncomment out line 24 and 27-31 of expiredMediaChecker
2. If the file id on line 24 has already been deleted, just choose another one from your logged list of expired files.
3. Make a note of the file's:
    1. filePath – to check whether it has been deleted
    2. projectId - so you can check the transcript status
4. Check the firebase console to ensure the file exists and note the current transcript status.  Hint: Transcript file path is: /projects/{ projectId }/transcripts/{ id }
5. Run the function and then observe in the firebase console:
    1. The file has been deleted (no longer exists in firebase)
    2. The transcript status is now set to ‘expired’


