### PR TITLE
fix: i104[storybook] remove generic fa iconstyle

### DIFF
--- a/src/Components/PaperEditor/TranscriptsContainer/LabelsList/index.js
+++ b/src/Components/PaperEditor/TranscriptsContainer/LabelsList/index.js
@@ -61,7 +61,7 @@ const LabelsList = (props) => {
             showButtonSize={ 'sm' }
             showButtonText={
               <span>
-                <FontAwesomeIcon icon={ faPen } />
+                <FontAwesomeIcon icon={ faPen } className="LabelsList__action-icon"/>
               </span> }
           />
         </Col>
@@ -75,7 +75,7 @@ const LabelsList = (props) => {
             } }
             disabled={ false }
           >
-            <FontAwesomeIcon icon={ faTrash } />
+            <FontAwesomeIcon icon={ faTrash } className="LabelsList__action-icon"/>
           </Button>
         </Col>
       </>

--- a/src/Components/PaperEditor/TranscriptsContainer/LabelsList/index.scss
+++ b/src/Components/PaperEditor/TranscriptsContainer/LabelsList/index.scss
@@ -45,9 +45,8 @@
     padding-right: 26px;
     width: 100%;
   }
-}
 
-.svg-inline--fa {
-  color: #222222;
+  &action-icon {
+    color: #222222;
+  }
 }
-


### PR DESCRIPTION
**Is your Pull Request request related to another [issue](https://github.com/bbc/react-transcript-editor/issues) in this repository ?**      
<!-- _If so please link to other issues and PRs as appropriate_ -->
Related to issue[ 104 opened in the Storybook repo](https://github.com/bbc/digital-paper-edit-storybook/issues/104)

**Describe what the PR does**    
<!-- _A clear and concise description of what the PR does. Feel free to use bulletpoints and checkboxes if needed [...]_ -->
Removes generic font awesome icon styling rule and applies icon styling only to selected icons. 

**State whether the PR is ready for review or whether it needs extra work**    
<!-- _If you are still working on it and just setting it up for later review, or if it's ready to be reviewed for merging_ -->
Ready 

**Additional context**    
<!-- Add any other context or screenshots about the PR. -->
Updated UI: 
- icons in the Label Modal are black 
- toggle view and help icons are white
<img width="1272" alt="Screenshot 2021-05-21 at 14 56 40" src="https://user-images.githubusercontent.com/39386043/119148822-caecef80-ba44-11eb-88d8-da250ee3f2df.png">

<!-- 
## User Story / Context
|As a ...|I want ...|So that ...|
|-|-|-|
|<Who>|<What>|<Why>|

## Acceptance Criteria
- <Criteria to satisfy the PR Issue>

## Definitions of Done
- [ ] Runs locally
- [ ] Runs remotely
- [ ] Test passes
- [ ] Demonstrated
- [ ] Deployed to Cosmos on Test and Live
- [ ] Documentation
  - [ ] Developer Documentation - [repo's README|<link>]
  - [ ] Stakeholder Documentation - [Confluence|<link>]
  - [ ] Operational Documentation - [Runbook|<link>]
- [ ] Peer reviewed by:
-->
