### PR TITLE
fix(dependencies): Bump version of Storybook for modal changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,16 +5,16 @@
   "requires": true,
   "dependencies": {
     "@auto-it/bot-list": {
-      "version": "10.27.1",
-      "resolved": "https://registry.npmjs.org/@auto-it/bot-list/-/bot-list-10.27.1.tgz",
-      "integrity": "sha512-2k311ZFy8GMABLS7GRN5MnE9DCoGkCi8h7LWvvIy/B6BAhW892WgyV2Lxcql3aP6B5GhOv+5UjB5wgKarwaCQA=="
+      "version": "10.29.0",
+      "resolved": "https://registry.npmjs.org/@auto-it/bot-list/-/bot-list-10.29.0.tgz",
+      "integrity": "sha512-CYM/cTrSUT2WiLPr/EgcdwdyKBn04idqnFh/Al7NJC9uaQcYya5lciceOwDNIgG/k71+whrbctdBG7k/Jwh28w=="
     },
     "@auto-it/core": {
-      "version": "10.27.1",
-      "resolved": "https://registry.npmjs.org/@auto-it/core/-/core-10.27.1.tgz",
-      "integrity": "sha512-cT9kCoz0Jnu4xtQTGUSH6b59Fwc41Pt/X5T/3/XRF8NimpsUGAIZRIs/UCQMAWCHzfZIUdlFQjvrPFF9rjjfiA==",
+      "version": "10.29.0",
+      "resolved": "https://registry.npmjs.org/@auto-it/core/-/core-10.29.0.tgz",
+      "integrity": "sha512-sHCVbzx7nLMOP/nXs/s2WYu/ARSwN2b2vZwMooFEHFYx6JTGVGHUWq8CAoaTINCiY9ti2Z2Ulsbmmqh2twIAOw==",
       "requires": {
-        "@auto-it/bot-list": "10.27.1",
+        "@auto-it/bot-list": "10.29.0",
         "@endemolshinegroup/cosmiconfig-typescript-loader": "^3.0.2",
         "@octokit/plugin-enterprise-compatibility": "^1.2.2",
         "@octokit/plugin-retry": "^3.0.1",
@@ -45,7 +45,7 @@
         "requireg": "^0.2.2",
         "semver": "^7.0.0",
         "signale": "^1.4.0",
-        "tapable": "^2.0.0-beta.2",
+        "tapable": "^2.2.0",
         "terminal-link": "^2.1.1",
         "tinycolor2": "^1.4.1",
         "ts-node": "^9.1.1",
@@ -126,12 +126,12 @@
       }
     },
     "@auto-it/npm": {
-      "version": "10.27.1",
-      "resolved": "https://registry.npmjs.org/@auto-it/npm/-/npm-10.27.1.tgz",
-      "integrity": "sha512-TAu2+qB6SV4MtZF0gYq4RzchcZpe3Ezn9i89FBayIOfL9x8QXA/TiuClzz6Vxp1pVGzFC1lGahs2QyLXe318WQ==",
+      "version": "10.29.0",
+      "resolved": "https://registry.npmjs.org/@auto-it/npm/-/npm-10.29.0.tgz",
+      "integrity": "sha512-gSMUqy5d6YW1n4bT3GTQWwI6jpHr+2a29h4XOe4d5bFoGmNpObkXRQPDfJ2rm7ji/qfkNdRSE4VZA7FZ9i8cJA==",
       "requires": {
-        "@auto-it/core": "10.27.1",
-        "@auto-it/package-json-utils": "10.27.1",
+        "@auto-it/core": "10.29.0",
+        "@auto-it/package-json-utils": "10.29.0",
         "await-to-js": "^3.0.0",
         "endent": "^2.0.1",
         "env-ci": "^5.0.1",
@@ -157,21 +157,21 @@
       }
     },
     "@auto-it/package-json-utils": {
-      "version": "10.27.1",
-      "resolved": "https://registry.npmjs.org/@auto-it/package-json-utils/-/package-json-utils-10.27.1.tgz",
-      "integrity": "sha512-sCff/n7EBVoYk7+TVBhvbNZVKDTg4/9ultRL9PRIwpx6QMW3OChSudsPtpqIudeySyT9q1IAOkXJsPQrBEwtjA==",
+      "version": "10.29.0",
+      "resolved": "https://registry.npmjs.org/@auto-it/package-json-utils/-/package-json-utils-10.29.0.tgz",
+      "integrity": "sha512-CNhjZw59nWTafckQkz++5SH524BRBpgttSYMKpf494kyz7WTCay2jf9JXs72wK6PWCgmawfqVjZHRX1g1zpK0A==",
       "requires": {
         "parse-author": "^2.0.0",
         "parse-github-url": "1.0.2"
       }
     },
     "@auto-it/released": {
-      "version": "10.27.1",
-      "resolved": "https://registry.npmjs.org/@auto-it/released/-/released-10.27.1.tgz",
-      "integrity": "sha512-QPggG0UZZpDYTenKNKhuoJp2pk7/XxBVP0Bjmk1fHsPznOKIHNSudqrGjsQALUQzvM9DmIPMLJ0ZykwkIbQa1g==",
+      "version": "10.29.0",
+      "resolved": "https://registry.npmjs.org/@auto-it/released/-/released-10.29.0.tgz",
+      "integrity": "sha512-/GuDzC3chkUAitQgMG3oJ/JYzOwmbOndeIU/66gbxNkTFNSNst/JdDoTzOBMAhCgC8AlrqjqzzwNuVNFi4Jv4Q==",
       "requires": {
-        "@auto-it/bot-list": "10.27.1",
-        "@auto-it/core": "10.27.1",
+        "@auto-it/bot-list": "10.29.0",
+        "@auto-it/core": "10.29.0",
         "deepmerge": "^4.0.0",
         "fp-ts": "^2.5.3",
         "io-ts": "^2.1.2",
@@ -1386,9 +1386,9 @@
       }
     },
     "@bbc/digital-paper-edit-storybook": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/@bbc/digital-paper-edit-storybook/-/digital-paper-edit-storybook-1.25.0.tgz",
-      "integrity": "sha512-RkXIjhxaOs+fPCskdCu00kTVMPQNbPm+gr2RxyYq46RE7Rpigt0SisBM9itSkJHgMfmHQRpfClsmGeAifvLGyA==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@bbc/digital-paper-edit-storybook/-/digital-paper-edit-storybook-1.26.0.tgz",
+      "integrity": "sha512-Neysi36sOwrbmntWbnqAwtlKDFIpggLj4cMTMOTc9IbIhicdRIQErut71dWAycJNkDGWyU8qMYdwU+67X4vsuA==",
       "requires": {
         "@bbc/react-transcript-editor": "^1.0.4",
         "@fortawesome/fontawesome-svg-core": "^1.2.19",
@@ -3019,9 +3019,9 @@
       }
     },
     "@octokit/openapi-types": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-7.0.0.tgz",
-      "integrity": "sha512-gV/8DJhAL/04zjTI95a7FhQwS6jlEE0W/7xeYAzuArD0KVAVWDLP2f3vi98hs3HLTczxXdRK/mF0tRoQPpolEw=="
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-7.2.1.tgz",
+      "integrity": "sha512-IHQJpLciwzwDvciLxiFj3IEV5VYn7lSVcj5cu0jbTwMfK4IG6/g8SPrVp3Le1VRzIiYSRcBzm1dA7vgWelYP3Q=="
     },
     "@octokit/plugin-enterprise-compatibility": {
       "version": "1.2.11",
@@ -3114,11 +3114,11 @@
       }
     },
     "@octokit/types": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.14.2.tgz",
-      "integrity": "sha512-wiQtW9ZSy4OvgQ09iQOdyXYNN60GqjCL/UdMsepDr1Gr0QzpW6irIKbH3REuAHXAhxkEk9/F2a3Gcs1P6kW5jA==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.16.0.tgz",
+      "integrity": "sha512-EktqSNq8EKXE82a7Vw33ozOEhFXIRik+rZHJTHAgVZRm/p2K5r5ecn5fVpRkLCm3CAVFwchRvt3yvtmfbt2LCQ==",
       "requires": {
-        "@octokit/openapi-types": "^7.0.0"
+        "@octokit/openapi-types": "^7.2.0"
       }
     },
     "@panva/asn1.js": {
@@ -5205,13 +5205,13 @@
       "integrity": "sha1-0IiFvmubv5Q5/gh8dihyRfCoFFA="
     },
     "auto": {
-      "version": "10.27.1",
-      "resolved": "https://registry.npmjs.org/auto/-/auto-10.27.1.tgz",
-      "integrity": "sha512-c7NkU54NN453+YDWZ+ytdE2sulDB8jqW1hU0tCWfN60KpwKiLW2R3b+WuyjKwzF/9iXJNTAXpa3lla2D+DOXTA==",
+      "version": "10.29.0",
+      "resolved": "https://registry.npmjs.org/auto/-/auto-10.29.0.tgz",
+      "integrity": "sha512-bfVo98G9NpEq04bL5G0ifu7VXVzdxA7CugbIOdv6GmfOsyune/Dso1tg1PCIakTwMUpqWtg4NmO9h7qSt6NxyQ==",
       "requires": {
-        "@auto-it/core": "10.27.1",
-        "@auto-it/npm": "10.27.1",
-        "@auto-it/released": "10.27.1",
+        "@auto-it/core": "10.29.0",
+        "@auto-it/npm": "10.29.0",
+        "@auto-it/released": "10.29.0",
         "await-to-js": "^3.0.0",
         "chalk": "^4.0.0",
         "command-line-application": "^0.10.1",
@@ -14690,9 +14690,9 @@
       }
     },
     "markdown-to-jsx": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.2.tgz",
-      "integrity": "sha512-O8DMCl32V34RrD+ZHxcAPc2+kYytuDIoQYjY36RVdsLK7uHjgNVvFec4yv0X6LgB4YEZgSvK5QtFi5YVqEpoMA=="
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.3.tgz",
+      "integrity": "sha512-jtQ6VyT7rMT5tPV0g2EJakEnXLiPksnvlYtwQsVVZ611JsWGN8bQ1tVSDX4s6JllfEH6wmsYxNjTUAMrPmNA8w=="
     },
     "material-colors": {
       "version": "1.2.6",
@@ -22317,9 +22317,9 @@
       }
     },
     "telejson": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/telejson/-/telejson-5.3.2.tgz",
-      "integrity": "sha512-lvtKMZ2ONxgwcMrhUs2W6zT9Z/IwUY8ZZ6D4DvUtLMl7txBNmtY0GnbMBCQ3JevQpkwxYZ5Zu0a+AR7xCzJJnQ==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/telejson/-/telejson-5.3.3.tgz",
+      "integrity": "sha512-PjqkJZpzEggA9TBpVtJi1LVptP7tYtXB6rEubwlHap76AMjzvOdKX41CxyaW7ahhzDU1aftXnMCx5kAPDZTQBA==",
       "requires": {
         "@types/is-function": "^1.0.0",
         "global": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "@bbc/aes31-adl-composer": "^1.1.0",
-    "@bbc/digital-paper-edit-storybook": "^1.25.0",
+    "@bbc/digital-paper-edit-storybook": "^1.26.0",
     "@bbc/fcpx-xml-composer": "^1.0.0",
     "@bbc/react-transcript-editor": "^1.4.0",
     "@datapunt/matomo-tracker-react": "^0.3.1",


### PR DESCRIPTION
**Is your Pull Request request related to another [issue](https://github.com/bbc/react-transcript-editor/issues) in this repository ?**      
<!-- _If so please link to other issues and PRs as appropriate_ -->
The changes to modals in #242 didn't deploy, so bumping the Storybook version

**Describe what the PR does**    
<!-- _A clear and concise description of what the PR does. Feel free to use bulletpoints and checkboxes if needed [...]_ -->

- Bumps Storybook version to 1.26

**State whether the PR is ready for review or whether it needs extra work**    
<!-- _If you are still working on it and just setting it up for later review, or if it's ready to be reviewed for merging_ -->

Ready

**Additional context**    
<!-- Add any other context or screenshots about the PR. -->


<!-- 