### PR TITLE
261 Fix media export

### DIFF
--- a/src/Components/PaperEditor/ProgrammeScriptContainer/ExportDropdown/index.js
+++ b/src/Components/PaperEditor/ProgrammeScriptContainer/ExportDropdown/index.js
@@ -24,6 +24,7 @@ const ExportDropdown = (props) => {
   const elements = props.elements;
   const transcripts = props.transcripts;
   const projectTitle = props.projectTitle;
+  const storage = props.storage;
 
   const [ showADL, setShowADL ] = useState(false);
   const [ showMedia, setShowMedia ] = useState(false);
@@ -86,7 +87,8 @@ const ExportDropdown = (props) => {
   };
 
   const getMediaUrl = async (item) => {
-    return props.handleGetMediaUrl(item);
+
+    return props.handleGetMediaUrl(storage, item);
   };
 
   const handleDownloadMedia = async () => {

--- a/src/Components/PaperEditor/ProgrammeScriptContainer/index.js
+++ b/src/Components/PaperEditor/ProgrammeScriptContainer/index.js
@@ -522,6 +522,7 @@ const ProgrammeScriptContainer = (props) => {
                   transcripts={ transcripts }
                   title={ title }
                   elements={ elements }
+                  storage={ firebase.storage.storage }
                   handleGetMediaUrl = { getMediaUrl }
                 />
                 : (<Button variant="outline-secondary" disabled>

--- a/src/Components/PaperEditor/ProgrammeScriptContainer/utils/compilePlaylist.js
+++ b/src/Components/PaperEditor/ProgrammeScriptContainer/utils/compilePlaylist.js
@@ -15,7 +15,10 @@ const paperEditsAreContinuous = (lastPlaylistItem, currentEdit) => {
   return areFromSameTranscript && areConsecutiveClips;
 };
 
-const getMediaUrl = async (storage, item) => storage.ref(item.ref).getDownloadURL();
+const getMediaUrl = async (storage, item) => {
+
+  return await storage.ref(item.ref).getDownloadURL();
+};
 
 const compilePlaylist = async (paperEdits, transcripts, storage) => {
   const results = paperEdits.reduce((prevResult, paperEdit) => {
@@ -51,6 +54,7 @@ const compilePlaylist = async (paperEdits, transcripts, storage) => {
 
   return Promise.all(
     results.map(async (item) => {
+      console.log('58 item: ', item);
       const src = await getMediaUrl(storage, item);
 
       return { ...item, src };

--- a/src/Components/PaperEditor/ProgrammeScriptContainer/utils/compilePlaylist.js
+++ b/src/Components/PaperEditor/ProgrammeScriptContainer/utils/compilePlaylist.js
@@ -54,7 +54,6 @@ const compilePlaylist = async (paperEdits, transcripts, storage) => {
 
   return Promise.all(
     results.map(async (item) => {
-      console.log('58 item: ', item);
       const src = await getMediaUrl(storage, item);
 
       return { ...item, src };


### PR DESCRIPTION
**Is your Pull Request request related to another [issue](https://github.com/bbc/react-transcript-editor/issues) in this repository ?**      
<!-- _If so please link to other issues and PRs as appropriate_ -->
Fixes #261 

**Describe what the PR does**    
<!-- _A clear and concise description of what the PR does. Feel free to use bulletpoints and checkboxes if needed [...]_ -->

- [x] Passes storage as a prop to the ExportDropdown element from the ProgrammeScriptContainer

**State whether the PR is ready for review or whether it needs extra work**    
<!-- _If you are still working on it and just setting it up for later review, or if it's ready to be reviewed for merging_ -->
Ready

**Additional context**    
<!-- Add any other context or screenshots about the PR. -->
To test: 
- Run the app
- Select the "Download media" option from the "Export" dropdown on this project: http://localhost:3000/#/projects/BBDpT2KIRMPXjY47Ufjj/paperedits/fKuOM1JH9Q0xFfe5qiqc
- Open your media files after download to make sure they play back

Additional issues:
- This errors if your programme script contains references to expired media. Expected behaviour would probably be to present any media you do find, and ignore expired media - or else, in the modal, display expired media with deactivated download buttons. I think this is outside the scope of the ticket as we have lots of functionality around expired media that has not been implemented yet. Run and see: http://localhost:3000/#/projects/Bd6tblAMtbngsjQMnU0C/paperedits/1JjFHzEU7arzrffLhYL8