### PR TITLE
269 Sort transcripts by upload date

### DIFF
--- a/src/Components/Workspace/Transcripts/index.js
+++ b/src/Components/Workspace/Transcripts/index.js
@@ -16,7 +16,6 @@ const sortItems = (items) => {
 
 const Transcripts = (props) => {
   const items = props.items;
-  console.log(items.length);
   const uploadTasks = props.uploadTasks;
   const sortedItems = sortItems(items);
 

--- a/src/Components/Workspace/Transcripts/index.js
+++ b/src/Components/Workspace/Transcripts/index.js
@@ -5,11 +5,22 @@ import TranscriptRow from '@bbc/digital-paper-edit-storybook/TranscriptRow';
 import { formatDates } from '../../../Util/time';
 import './index.scss';
 
+const sortItems = (items) => {
+  return items.sort((a, b) => {
+    const aTime = a.uploaded ? a.uploaded : a.created;
+    const bTime = b.uploaded ? b.uploaded : b.created;
+
+    return bTime - aTime;
+  });
+};
+
 const Transcripts = (props) => {
   const items = props.items;
+  console.log(items.length);
   const uploadTasks = props.uploadTasks;
+  const sortedItems = sortItems(items);
 
-  const TranscriptRows = items.map(item => {
+  const TranscriptRows = sortedItems.map(item => {
     const key = `card-transcript-${ item.id }`;
     const { created, updated } = formatDates(item);
     const progress = uploadTasks.get(item.id);

--- a/src/Components/Workspace/index.js
+++ b/src/Components/Workspace/index.js
@@ -304,6 +304,9 @@ const WorkspaceView = props => {
     const file = transcript.file;
     delete transcript.file;
 
+    const uploaded = new Date();
+    console.log('created: ', uploaded);
+
     const newTranscript = await createOrUpdateCollectionItem({
       ...transcript,
       title: transcript.title,
@@ -311,6 +314,7 @@ const WorkspaceView = props => {
       description: transcript.description ? transcript.description : '',
       status: 'uploading',
       duration: duration,
+      uploaded: uploaded
     }, createTranscript, updateTranscript);
 
     asyncUploadFile(newTranscript.id, file);

--- a/src/Components/Workspace/index.js
+++ b/src/Components/Workspace/index.js
@@ -174,7 +174,7 @@ const WorkspaceView = props => {
 
   const handleUploadError = (taskId, error) => {
     console.error('Failed to upload file: ', error);
-    const newTasks = new Map(uploadTasks); // shallow clone
+    const newTasks = new Map(uploadTasks);
     newTasks.delete(taskId);
     setUploadTasks(newTasks);
 
@@ -227,7 +227,7 @@ const WorkspaceView = props => {
           handleUploadError(taskId, error);
         },
         () => {
-          handleUploadComplete(newTranscript, transcriptItems);
+          handleUploadComplete(newTranscript);
         }
       );
     };


### PR DESCRIPTION
**Is your Pull Request request related to another [issue](https://github.com/bbc/react-transcript-editor/issues) in this repository ?**      
<!-- _If so please link to other issues and PRs as appropriate_ -->
Fixes #269

**Describe what the PR does**    
<!-- _A clear and concise description of what the PR does. Feel free to use bulletpoints and checkboxes if needed [...]_ -->
- [x] Adds an 'uploaded' field to transcript documents in Firebase, which is populated before the 'created' date
- [x] Adds a sort on the Transcript column

**State whether the PR is ready for review or whether it needs extra work**    
<!-- _If you are still working on it and just setting it up for later review, or if it's ready to be reviewed for merging_ -->
Ready

**Additional context**    
<!-- Add any other context or screenshots about the PR. -->
Out of scope: Fixing the wonky progress bars on double-upload

To test:
- Upload some media in the project view. 

Expected behaviour: The cards should not change their place in the Transcript column throughout the transcribing process.

<!-- 
## User Story / Context
|As a ...|I want ...|So that ...|
|-|-|-|
|<Who>|<What>|<Why>|

## Acceptance Criteria
- <Criteria to satisfy the PR Issue>

## Definitions of Done
- [ ] Runs locally
- [ ] Runs remotely
- [ ] Test passes
- [ ] Demonstrated
- [ ] Deployed to Cosmos on Test and Live
- [ ] Documentation
  - [ ] Developer Documentation - [repo's README|<link>]
  - [ ] Stakeholder Documentation - [Confluence|<link>]
  - [ ] Operational Documentation - [Runbook|<link>]
- [ ] Peer reviewed by:
-->
