### PR TITLE
added fileName as label field

### DIFF
--- a/src/Components/PaperEditor/ProgrammeScriptContainer/ExportDropdown/edl.js
+++ b/src/Components/PaperEditor/ProgrammeScriptContainer/ExportDropdown/edl.js
@@ -67,7 +67,7 @@ const formatToADLEvent = (transcript, element) => {
     sampleRate: transcript.metadata
       ? transcript.metadata.sampleRate
       : defaultSampleRate,
-    label: '',
+    label: transcript.fileName,
     uuid: transcript.uuid,
     path: transcript.path
   };


### PR DESCRIPTION
fixes #272 

**Describe what the PR does**    
Populates NAME field in SaDiE export so clips are labelled properly within SaDiE.

Issue raised from user feedback session with Jonathan Glover

**State whether the PR is ready for review or whether it needs extra work**    
RFR 

**Additional context**    
Once pushed to live, will need Jonathan Glover to re-test and confirm this problem is resolved.

## Acceptance Criteria

- [ ] Export ADL and open in text/code editor
- [ ] Each cut entry has the NAME field populated like below

![Screenshot 2021-05-28 at 15 55 23](https://user-images.githubusercontent.com/26869008/120003142-5f1eff80-bfcd-11eb-87ab-99eac95b0b8b.png)

