### PR TITLE
279: Password reset

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -17,14 +17,14 @@ const App = (props) => {
   const [ user, setUser ] = useState();
 
   useEffect(() => {
-    const authListener = props.firebase.auth.onAuthStateChanged(() =>
-      setAuthUser(user)
+    const authListener = props.firebase.auth.onAuthStateChanged((authStateUser) =>
+      setAuthUser(authStateUser)
     );
 
     return () => {
       authListener();
     };
-  }, [ props.firebase.auth, user ]);
+  }, [ props.firebase.auth ]);
 
   useEffect(() => {
     const userCollection = new Collection(props.firebase, '/users');

--- a/src/App.js
+++ b/src/App.js
@@ -17,14 +17,14 @@ const App = (props) => {
   const [ user, setUser ] = useState();
 
   useEffect(() => {
-    const authListener = props.firebase.auth.onAuthStateChanged((user) =>
+    const authListener = props.firebase.auth.onAuthStateChanged(() =>
       setAuthUser(user)
     );
 
     return () => {
       authListener();
     };
-  }, [ props.firebase.auth ]);
+  }, [ props.firebase.auth, user ]);
 
   useEffect(() => {
     const userCollection = new Collection(props.firebase, '/users');

--- a/src/Components/PaperEditor/ProgrammeScriptContainer/ExportDropdown/index.js
+++ b/src/Components/PaperEditor/ProgrammeScriptContainer/ExportDropdown/index.js
@@ -168,7 +168,8 @@ ExportDropdown.propTypes = {
   handleGetMediaUrl: PropTypes.func,
   projectTitle: PropTypes.any,
   title: PropTypes.any,
-  transcripts: PropTypes.any
+  transcripts: PropTypes.any,
+  storage: PropTypes.object
 };
 
 export default ExportDropdown;

--- a/src/Components/PaperEditor/ProgrammeScriptContainer/ExportDropdown/programme-script-json-to-docx.js
+++ b/src/Components/PaperEditor/ProgrammeScriptContainer/ExportDropdown/programme-script-json-to-docx.js
@@ -26,7 +26,7 @@ const programmeScriptJsonToDocx = (edlJson, title, includeClipReference) => {
         new Paragraph({
           children: [
             new TextRun({
-              text: `Voice Over:\t`,
+              text: 'Voice Over:\t',
               italics: false,
               bold: true,
             }),
@@ -42,7 +42,7 @@ const programmeScriptJsonToDocx = (edlJson, title, includeClipReference) => {
     } else if (event.type === 'note') {
       sections.push(
         new Paragraph({
-          children: [ new TextRun({ text: `Notes:\t`, italics: true, bold: true }), new TextRun({ text: `${ event.text }`, italics: true }) ],
+          children: [ new TextRun({ text: 'Notes:\t', italics: true, bold: true }), new TextRun({ text: `${ event.text }`, italics: true }) ],
           spacing: {
             after: 200,
           },

--- a/src/Components/PasswordReset/index.js
+++ b/src/Components/PasswordReset/index.js
@@ -8,10 +8,10 @@ import Col from 'react-bootstrap/Col';
 import Alert from 'react-bootstrap/Alert';
 import Button from 'react-bootstrap/Button';
 import Container from 'react-bootstrap/Container';
+import './index.scss';
 
 const PasswordResetPage = () => (
-  <Container style={ { marginBottom: '5em', marginTop: '1em', border: '1px solid #6b6b6b',
-    width: '398px', height: '354px', padding: '1.5em', position: 'relative' } }>
+  <Container className='PasswordReset__container'>
     <PasswordResetForm />
   </Container>
 );
@@ -63,7 +63,7 @@ const PasswordResetFormBase = ({ firebase, location: { search } }) => {
     );
 
     return (
-      <Alert variant='danger' style={ { fontSize: '12px', padding: '8px', marginTop: '8px' } }>
+      <Alert variant='danger' className='PasswordReset__error'>
         {error.code === 'auth/user-not-found' ? notFoundError : error.message}
       </Alert>
     );
@@ -71,19 +71,19 @@ const PasswordResetFormBase = ({ firebase, location: { search } }) => {
 
   const renderForm = () => (
     <>
-      <h2 style={ { marginBottom: '0.5em' } }>Password reset</h2>
+      <h2 className='PasswordReset__header'>Password reset</h2>
       <Form onSubmit={ onSubmit }>
         <Form.Row>
           <Col>
             <Form.Group controlId="email" >
               <Form.Label>Email address</Form.Label>
-              <Form.Control value={ email } onChange={ onEmailChange } type="email" placeholder="Enter email" />
+              <Form.Control value={ email } onChange={ onEmailChange } type="email" placeholder="Enter email" isInvalid={ !!error } />
               { error ? renderErrorAlert() : null }
             </Form.Group>
           </Col>
         </Form.Row>
         <Button
-          style={ { position: 'absolute', bottom: '4em' } }
+          className='PasswordReset__submit'
           disabled={ !isValid }
           variant="primary"
           type="submit">
@@ -95,7 +95,7 @@ const PasswordResetFormBase = ({ firebase, location: { search } }) => {
 
   const renderSuccessMessage = () => (
     <div>
-      <h2 style={ { marginBottom: '0.5em' } }>Password reset successful</h2>
+      <h2 className='PasswordReset__header'>Password reset successful</h2>
       <p>
         Please check your inbox.<br />
         We’ve just sent a reset link for your password.<br />
@@ -103,7 +103,7 @@ const PasswordResetFormBase = ({ firebase, location: { search } }) => {
       </p>
       <p>Can’t find it? Check your spam folder.</p>
       <p>
-        <Link to={ { pathname: '/reset', search: `?email=${ email }` } } style={ { textDecoration: 'underline', color: '#363636' } }
+        <Link to={ { pathname: '/reset', search: `?email=${ email }` } } className='PasswordReset__link'
           onClick={ () => setIsSubmitted(false) }>
           Or resend the email.
         </Link>

--- a/src/Components/PasswordReset/index.js
+++ b/src/Components/PasswordReset/index.js
@@ -1,0 +1,77 @@
+import PropTypes from 'prop-types';
+import React, { useState } from 'react';
+import { withRouter } from 'react-router-dom';
+import { compose } from '@shakacode/recompose';
+import { withFirebase } from '../Firebase';
+import * as ROUTES from '../../constants/routes';
+import Form from 'react-bootstrap/Form';
+import Col from 'react-bootstrap/Col';
+import Button from 'react-bootstrap/Button';
+import Container from 'react-bootstrap/Container';
+
+const PasswordResetPage = () => (
+  <Container style={ { marginBottom: '5em', marginTop: '1em', border: '1px solid #6b6b6b', width: '398px', height: '354px', padding: '1.5em', position: 'relative' } }>
+    <h2 style={ { marginBottom: '0.5em' } }>Password reset</h2>
+    <PasswordResetForm />
+  </Container>
+);
+
+const PasswordResetFormBase = props => {
+
+  const [ email, setEmail ] = useState('');
+  const [ error, setError ] = useState();
+
+  const onSubmit = async event => {
+    // Prevent form from reloading
+    event.preventDefault();
+
+    try {
+      await props.firebase.doSignInWithEmailAndPassword(email);
+      props.history.push(ROUTES.PROJECTS);
+    } catch (err) {
+      setError(err);
+      console.error(err);
+    }
+  };
+
+  const onEmailChange = event => {
+    setEmail(event.target.value);
+  };
+
+  const isInvalid = email === '';
+
+  return (
+    <Form onSubmit={ onSubmit }>
+      <Form.Row>
+        <Col>
+          <Form.Group controlId="email" >
+            <Form.Label>Email address</Form.Label>
+            <Form.Control value={ email } onChange={ onEmailChange } type="email" placeholder="Enter email" />
+          </Form.Group>
+        </Col>
+      </Form.Row>
+      <Button
+        style={ { position: 'absolute', bottom: '4em' } }
+        disabled={ isInvalid }
+        variant="primary"
+        type="submit">
+        Send password reset email
+      </Button>
+      {error && <p>{error.message}</p>}
+    </Form>
+  );
+};
+
+PasswordResetFormBase.propTypes = {
+  firebase: PropTypes.shape({
+    doSignInWithEmailAndPassword: PropTypes.func
+  }),
+  history: PropTypes.shape({
+    push: PropTypes.func
+  })
+};
+
+// HOC with router and firebase
+const PasswordResetForm = compose(withRouter, withFirebase)(PasswordResetFormBase);
+
+export default PasswordResetPage;

--- a/src/Components/PasswordReset/index.js
+++ b/src/Components/PasswordReset/index.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
-import { withRouter } from 'react-router-dom';
+import { withRouter, Link } from 'react-router-dom';
 import { compose } from '@shakacode/recompose';
 import { withFirebase } from '../Firebase';
 import Form from 'react-bootstrap/Form';
@@ -10,8 +10,8 @@ import Button from 'react-bootstrap/Button';
 import Container from 'react-bootstrap/Container';
 
 const PasswordResetPage = () => (
-  <Container style={ { marginBottom: '5em', marginTop: '1em', border: '1px solid #6b6b6b', width: '398px', height: '354px', padding: '1.5em', position: 'relative' } }>
-    <h2 style={ { marginBottom: '0.5em' } }>Password reset</h2>
+  <Container style={ { marginBottom: '5em', marginTop: '1em', border: '1px solid #6b6b6b',
+    width: '398px', height: '354px', padding: '1.5em', position: 'relative' } }>
     <PasswordResetForm />
   </Container>
 );
@@ -20,6 +20,7 @@ const PasswordResetFormBase = props => {
   const [ email, setEmail ] = useState('');
   const [ error, setError ] = useState();
   const [ isInvalid, setIsInvalid ] = useState(true);
+  const [ isSubmitted, setIsSubmitted ] = useState(false);
 
   const onSubmit = async event => {
     event.preventDefault();
@@ -28,6 +29,7 @@ const PasswordResetFormBase = props => {
     try {
       await props.firebase.doPasswordReset(email);
       window.localStorage.setItem('emailForSignIn', email);
+      setIsSubmitted(true);
     } catch (resetError) {
       setError(resetError);
       setIsInvalid(true);
@@ -64,26 +66,48 @@ const PasswordResetFormBase = props => {
     );
   };
 
-  return (
-    <Form onSubmit={ onSubmit }>
-      <Form.Row>
-        <Col>
-          <Form.Group controlId="email" >
-            <Form.Label>Email address</Form.Label>
-            <Form.Control value={ email } onChange={ onEmailChange } type="email" placeholder="Enter email" />
-            { error ? renderErrorAlert() : null }
-          </Form.Group>
-        </Col>
-      </Form.Row>
-      <Button
-        style={ { position: 'absolute', bottom: '4em' } }
-        disabled={ isInvalid }
-        variant="primary"
-        type="submit">
-        Send password reset email
-      </Button>
-    </Form>
+  const renderForm = () => (
+    <>
+      <h2 style={ { marginBottom: '0.5em' } }>Password reset</h2>
+      <Form onSubmit={ onSubmit }>
+        <Form.Row>
+          <Col>
+            <Form.Group controlId="email" >
+              <Form.Label>Email address</Form.Label>
+              <Form.Control value={ email } onChange={ onEmailChange } type="email" placeholder="Enter email" />
+              { error ? renderErrorAlert() : null }
+            </Form.Group>
+          </Col>
+        </Form.Row>
+        <Button
+          style={ { position: 'absolute', bottom: '4em' } }
+          disabled={ isInvalid }
+          variant="primary"
+          type="submit">
+          Send password reset email
+        </Button>
+      </Form>
+    </>
   );
+
+  const renderSuccessMessage = () => (
+    <div>
+      <h2 style={ { marginBottom: '0.5em' } }>Password reset successful</h2>
+      <p>
+        Please check your inbox.<br />
+        We’ve just sent a reset link for your password.<br />
+        It may take a few minutes to arrive.
+      </p>
+      <p>Can’t find it? Check your spam folder.</p>
+      <p>
+        <Link to="/reset" style={ { textDecoration: 'underline', color: '#363636' } } onClick={ () => setIsSubmitted(false) }>
+          Or resend the email.
+        </Link>
+      </p>
+    </div>
+  );
+
+  return isSubmitted ? renderSuccessMessage() : renderForm();
 };
 
 PasswordResetFormBase.propTypes = {

--- a/src/Components/PasswordReset/index.js
+++ b/src/Components/PasswordReset/index.js
@@ -16,10 +16,13 @@ const PasswordResetPage = () => (
   </Container>
 );
 
-const PasswordResetFormBase = props => {
-  const [ email, setEmail ] = useState('');
+const PasswordResetFormBase = ({ firebase, location: { search } }) => {
+  const params = new URLSearchParams(search);
+  const emailParam = params.get('email') || '';
+
+  const [ email, setEmail ] = useState(emailParam);
   const [ error, setError ] = useState();
-  const [ isInvalid, setIsInvalid ] = useState(true);
+  const [ isValid, setIsValid ] = useState(emailParam.length > 0);
   const [ isSubmitted, setIsSubmitted ] = useState(false);
 
   const onSubmit = async event => {
@@ -27,12 +30,12 @@ const PasswordResetFormBase = props => {
     setError(undefined);
 
     try {
-      await props.firebase.doPasswordReset(email);
+      await firebase.doPasswordReset(email);
       window.localStorage.setItem('emailForSignIn', email);
       setIsSubmitted(true);
     } catch (resetError) {
       setError(resetError);
-      setIsInvalid(true);
+      setIsValid(false);
       console.error(resetError);
     }
   };
@@ -41,9 +44,9 @@ const PasswordResetFormBase = props => {
     setEmail(event.target.value);
 
     if (event.target.value === '') {
-      setIsInvalid(true);
+      setIsValid(false);
     } else {
-      setIsInvalid(false);
+      setIsValid(true);
     }
 
     if (error) {
@@ -81,7 +84,7 @@ const PasswordResetFormBase = props => {
         </Form.Row>
         <Button
           style={ { position: 'absolute', bottom: '4em' } }
-          disabled={ isInvalid }
+          disabled={ !isValid }
           variant="primary"
           type="submit">
           Send password reset email
@@ -100,7 +103,8 @@ const PasswordResetFormBase = props => {
       </p>
       <p>Can’t find it? Check your spam folder.</p>
       <p>
-        <Link to="/reset" style={ { textDecoration: 'underline', color: '#363636' } } onClick={ () => setIsSubmitted(false) }>
+        <Link to={ { pathname: '/reset', search: `?email=${ email }` } } style={ { textDecoration: 'underline', color: '#363636' } }
+          onClick={ () => setIsSubmitted(false) }>
           Or resend the email.
         </Link>
       </p>

--- a/src/Components/PasswordReset/index.scss
+++ b/src/Components/PasswordReset/index.scss
@@ -1,0 +1,31 @@
+.PasswordReset {
+  &__container {
+    margin-bottom: 5em;
+    margin-top: 1em;
+    border: 1px solid #6b6b6b;
+    width: 398px;
+    height: 354px;
+    padding: 1.5em;
+    position: relative;
+  }
+
+  &__header {
+    margin-bottom: 0.5em;
+  }
+
+  &__error {
+    font-size: 0.75em;
+    padding: 0.5em;
+    margin-top: 0.5em;
+  }
+
+  &__submit {
+    position: absolute;
+    bottom: 4em;
+  }
+
+  &__link {
+    text-decoration: underline;
+    color: #363636;
+  }
+}

--- a/src/Components/Session/withAuthentication.js
+++ b/src/Components/Session/withAuthentication.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
 
 import AuthUserContext from './context';
 import { withFirebase } from '../Firebase';
@@ -31,6 +32,12 @@ const withAuthentication = Component => {
         <Component { ...props } />
       </AuthUserContext.Provider>
     );
+  };
+
+  WithAuthentication.propTypes = {
+    firebase: PropTypes.shape({
+      onAuthUserListener: PropTypes.func
+    })
   };
 
   return withFirebase(WithAuthentication);

--- a/src/Components/SignIn/index.js
+++ b/src/Components/SignIn/index.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
-import { withRouter } from 'react-router-dom';
+import { withRouter, Link } from 'react-router-dom';
 import { compose } from '@shakacode/recompose';
 import { withFirebase } from '../Firebase';
 import * as ROUTES from '../../constants/routes';
@@ -10,8 +10,8 @@ import Button from 'react-bootstrap/Button';
 import Container from 'react-bootstrap/Container';
 
 const SignInPage = () => (
-  <Container style={ { marginBottom: '5em', marginTop: '1em' } }>
-    <h2>Sign In</h2>
+  <Container style={ { marginBottom: '5em', marginTop: '1em', border: '1px solid black', width: '398px', padding: '1.5em' } }>
+    <h2 style={ { marginBottom: '0.5em' } }>Sign In</h2>
     <SignInForm />
   </Container>
 );
@@ -46,28 +46,33 @@ const SignInFormBase = props => {
   const isInvalid = password === '' || email === '';
 
   return (
-    <Form onSubmit={ onSubmit }>
-      <Form.Row>
-        <Col>
-          <Form.Group controlId="email" >
-            <Form.Label>Email address</Form.Label>
-            <Form.Control value={ email } onChange={ onEmailChange } type="email" placeholder="Enter email" />
-          </Form.Group>
-        </Col>
-        <Col>
-          <Form.Group controlId="password" >
-            <Form.Label>Password</Form.Label>
-            <Form.Control value={ password } onChange={ onPasswordChange } type="password" placeholder="Password" />
-          </Form.Group>
-        </Col>
-      </Form.Row>
-      <Button
-        disabled={ isInvalid }
-        variant="primary" type="submit">
-        Sign in
-      </Button>
-      {error && <p>{error.message}</p>}
-    </Form>
+    <>
+      <Form style={ { marginBottom: '1em' } } onSubmit={ onSubmit }>
+        <Form.Row>
+          <Col>
+            <Form.Group controlId="email" >
+              <Form.Label>Email address</Form.Label>
+              <Form.Control value={ email } onChange={ onEmailChange } type="email" placeholder="Enter email" />
+            </Form.Group>
+          </Col>
+        </Form.Row>
+        <Form.Row>
+          <Col>
+            <Form.Group controlId="password" >
+              <Form.Label>Password</Form.Label>
+              <Form.Control value={ password } onChange={ onPasswordChange } type="password" placeholder="Password" />
+            </Form.Group>
+          </Col>
+        </Form.Row>
+        <Button
+          disabled={ isInvalid }
+          variant="primary"type="submit">
+          Sign in
+        </Button>
+        {error && <p>{error.message}</p>}
+      </Form>
+      <Link to="/reset" style={ { textDecoration: 'underline', color: '#6b6b6b' } }>Password reset</Link>
+    </>
   );
 };
 
@@ -84,5 +89,3 @@ SignInFormBase.propTypes = {
 const SignInForm = compose(withRouter, withFirebase)(SignInFormBase);
 
 export default SignInPage;
-
-export { SignInForm };

--- a/src/Components/SignIn/index.js
+++ b/src/Components/SignIn/index.js
@@ -8,16 +8,16 @@ import Form from 'react-bootstrap/Form';
 import Col from 'react-bootstrap/Col';
 import Button from 'react-bootstrap/Button';
 import Container from 'react-bootstrap/Container';
+import './index.scss';
 
 const SignInPage = () => (
-  <Container style={ { marginBottom: '5em', marginTop: '1em', border: '1px solid black', width: '398px', padding: '1.5em' } }>
-    <h2 style={ { marginBottom: '0.5em' } }>Sign In</h2>
+  <Container className='SignIn__container'>
+    <h2 className='SignIn__header'>Sign In</h2>
     <SignInForm />
   </Container>
 );
 
 const SignInFormBase = props => {
-
   const [ email, setEmail ] = useState('');
   const [ password, setPassword ] = useState('');
   const [ error, setError ] = useState();
@@ -47,7 +47,7 @@ const SignInFormBase = props => {
 
   return (
     <>
-      <Form style={ { marginBottom: '1em' } } onSubmit={ onSubmit }>
+      <Form className='SignIn__form' onSubmit={ onSubmit }>
         <Form.Row>
           <Col>
             <Form.Group controlId="email" >
@@ -69,7 +69,7 @@ const SignInFormBase = props => {
         </Button>
         {error && <p>{error.message}</p>}
       </Form>
-      <Link to={ { pathname: '/reset', search: `?email=${ email }` } } style={ { textDecoration: 'underline', color: '#6b6b6b' } }>
+      <Link to={ { pathname: '/reset', search: `?email=${ email }` } } className='SignIn__link'>
         Password reset
       </Link>
     </>

--- a/src/Components/SignIn/index.js
+++ b/src/Components/SignIn/index.js
@@ -64,14 +64,14 @@ const SignInFormBase = props => {
             </Form.Group>
           </Col>
         </Form.Row>
-        <Button
-          disabled={ isInvalid }
-          variant="primary"type="submit">
+        <Button disabled={ isInvalid } variant="primary" type="submit">
           Sign in
         </Button>
         {error && <p>{error.message}</p>}
       </Form>
-      <Link to="/reset" style={ { textDecoration: 'underline', color: '#6b6b6b' } }>Password reset</Link>
+      <Link to={ { pathname: '/reset', search: `?email=${ email }` } } style={ { textDecoration: 'underline', color: '#6b6b6b' } }>
+        Password reset
+      </Link>
     </>
   );
 };

--- a/src/Components/SignIn/index.scss
+++ b/src/Components/SignIn/index.scss
@@ -1,0 +1,22 @@
+.SignIn {
+  &__container {
+    margin-bottom: 5em;
+    margin-top: 1em;
+    border: 1px solid black;
+    width: 398px;
+    padding: 1.5em;
+  }
+
+  &__header {
+    margin-bottom: 0.5em;
+  }
+
+  &__form {
+    margin-bottom: 1em;
+  }
+
+  &__link {
+    text-decoration: underline;
+    color: #363636;
+  }
+}

--- a/src/Components/SignOut/index.js
+++ b/src/Components/SignOut/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Button from 'react-bootstrap/Button';
+import PropTypes from 'prop-types';
 
 import { withFirebase } from '../Firebase';
 
@@ -8,5 +9,11 @@ const SignOutButton = ({ firebase }) => (
     Sign Out
   </Button>
 );
+
+SignOutButton.propTypes = {
+  firebase: PropTypes.shape({
+    doSignOut: PropTypes.func
+  })
+};
 
 export default withFirebase(SignOutButton);

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -7,6 +7,7 @@ import PaperEditor from './Components/PaperEditor';
 import Admin from './Components/Admin';
 import { Switch, Route, HashRouter } from 'react-router-dom';
 import SignIn from './Components/SignIn';
+import PasswordReset from './Components/PasswordReset';
 import * as ROUTES from './constants/routes';
 
 const PageNotFound = () => {
@@ -33,6 +34,7 @@ const Routes = ({ authUser }) => {
       <Switch>
         {landingRoute()}
         <Route exact path={ ROUTES.SIGN_IN } component={ SignIn } />
+        <Route exact path={ ROUTES.PASSWORD_RESET } component={ PasswordReset } />
         <Route exact path={ ROUTES.PROJECTS } component={ Projects } />
         <Route exact path={ ROUTES.WORKSPACE } component={ Workspace } />
         <Route exact path={ ROUTES.PAPER_EDITOR } component={ PaperEditor } />

--- a/src/constants/routes.js
+++ b/src/constants/routes.js
@@ -1,5 +1,6 @@
 export const LANDING = '/';
 export const SIGN_IN = '/signin';
+export const PASSWORD_RESET = '/reset';
 export const ADMIN = '/admin';
 export const PROJECTS = '/projects';
 export const WORKSPACE = '/projects/:projectId';

--- a/src/index.css
+++ b/src/index.css
@@ -6,9 +6,14 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  color: #363636;
 }
 
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;
+}
+
+a {
+ font-weight: 500;   
 }

--- a/src/index.css
+++ b/src/index.css
@@ -15,5 +15,5 @@ code {
 }
 
 a {
- font-weight: 500;   
+  font-weight: 500;
 }


### PR DESCRIPTION
**Is your Pull Request request related to another [issue](https://github.com/bbc/react-transcript-editor/issues) in this repository ?**      
#279 

**Describe what the PR does**    
- Implements the password reset flow [here](https://zpl.io/a8QLXG4) with a new /reset route
- Change the sign-in to match the design
- Fixes some old linting errors :)

**State whether the PR is ready for review or whether it needs extra work**    
RFR

**Additional context**    
I've not implemented the designs exactly as designed as the DPE header is a separate component that is visible after sign in and removing that would need a bit of refactoring, so I've just implemented the reset

**Acceptance Criteria**
- When the sign-in field is empty, on clicking Password reset it leads to that screen with an empty email field
- When the sign-in field is populated, on clicking Password reset it leads to that screen with the email field populated with that email
- When the email is invalid, or not registered with DPE an error message is shown (n.b. some validation errors are caught by the browser and look different from the design. The app handled errors use the closest design I could find in Bootstrap).
- After resetting a password, the success message is shown and the link to resend again takes you back to the reset form with the email field populated
- Resetting the password triggers an email to be sent to that account and the link to reset works

